### PR TITLE
feat: add support for custom controllers within the ComputedValues controller

### DIFF
--- a/src/controllers/computed-values/README.md
+++ b/src/controllers/computed-values/README.md
@@ -134,6 +134,7 @@ The compute lifecycle for each `ComputeValue` controller instance will be execut
 | `host` | LitElement | The host for the controller. | Yes |
 | `valuesOptions` | Array | The array of objects that each define a computed value. | Yes |
 | `valuesOptions[i].name` | String | The name of the computed value. Used to assign the internal `ComputedValue` instance to the `ComputedValues` instance. | Yes |
+| `valuesOptions[i].Controller` | Class | The controller instantiated internally for this particular value. By default this uses the `ComputedValue` controller, but it can be overriden with a custom controller. | |
 | `...valuesOptions[i]` | Object | The rest of the attributes for the object are passed to the internal `ComputedValue` instance constructor. See the `ComputedValue` constructor for details. | Yes |
 
 ## `ComputedValues` Instance Members

--- a/src/controllers/computed-values/computed-values.js
+++ b/src/controllers/computed-values/computed-values.js
@@ -2,8 +2,8 @@ import ComputedValue from './computed-value.js';
 
 export default class ComputedValues {
 	constructor(host, valuesOptions = []) {
-		valuesOptions.forEach(({ name, ...options }) => {
-			this[name] = new ComputedValue(host, options);
+		valuesOptions.forEach(({ Controller = ComputedValue, name, ...options }) => {
+			this[name] = new Controller(host, options);
 		});
 	}
 }


### PR DESCRIPTION
This change will allow custom controllers to be used within the ComputedValues array of controllers. This is needed in order to be able to control the order of execution of compute methods between custom controllers and any other controllers within the ComputedValues controller.