### PR TITLE
Init Drawer component in labs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,19 @@
 {
-  "extends": "brightspace/lit-config"
+  "extends": "brightspace/lit-config",
+  "overrides": [{
+    "files": [
+      "**/demo/**/*.html"
+    ],
+    "rules": {
+      "no-console": 0
+    }
+  },
+  {
+    "files": [
+      "**/lang/*.js"
+    ],
+    "rules": {
+      "quotes": 0
+    }
+  }]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,3 @@
 {
-  "extends": "brightspace/lit-config",
-  "overrides": [{
-    "files": [
-      "**/demo/**/*.html"
-    ],
-    "rules": {
-      "no-console": 0
-    }
-  },
-  {
-    "files": [
-      "**/lang/*.js"
-    ],
-    "rules": {
-      "quotes": 0
-    }
-  }]
+  "extends": "brightspace/lit-config"
 }

--- a/demo/.eslintrc.json
+++ b/demo/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [{
+    "files": [
+      "**/*.html"
+    ],
+    "rules": {
+      "no-console": 0
+    }
+  }]
+}

--- a/demo/components/drawer/index.html
+++ b/demo/components/drawer/index.html
@@ -8,12 +8,12 @@
             import '@brightspace-ui/core/components/button/button.js';
             import '../../../src/components/drawer/drawer.js';
         </script>
-        <title>Drawer</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta charset="UTF-8">
     </head>
-    <body>
+    <body unresolved>
         <d2l-demo-page page-title="Drawer">
+
             <h2>Drawer Positions</h2>
             <d2l-demo-snippet>
                 <template>
@@ -89,17 +89,18 @@
                     </script>
                 </template>
             </d2l-demo-snippet>
+
 			<h2>Drawer Sizes</h2>
             <d2l-demo-snippet>
                 <template>
-                    <d2l-button id="open-xs">xs</d2l-button>
-                    <d2l-button id="open-sm">sm</d2l-button>
-                    <d2l-button id="open-md">md</d2l-button>
-                    <d2l-button id="open-lg">lg</d2l-button>
-					<d2l-button id="open-xl">xl</d2l-button>
+                    <d2l-button id="open-xs">xsmall</d2l-button>
+                    <d2l-button id="open-sm">small</d2l-button>
+                    <d2l-button id="open-md">medium</d2l-button>
+                    <d2l-button id="open-lg">large</d2l-button>
+					<d2l-button id="open-xl">xlarge</d2l-button>
 					<d2l-button id="open-full">full</d2l-button>
-					<d2l-input-text id="custom-size-input" label="Custom Size Input" placeholder="% or px string"></d2l-input-text>
-					<d2l-button id="open-custom">Custom Size</d2l-button>
+					<d2l-button id="open-400">400px</d2l-button>
+					<d2l-button id="open-25-percent">25%</d2l-button>
                     <d2l-labs-drawer id="size-demo" label="Foobar">
                         <div>
                             <d2l-input-text id="nameId" label="Name" autofocus></d2l-input-text>
@@ -115,37 +116,41 @@
                     </d2l-labs-drawer>
                     <script>
 						document.querySelector('#open-xs').addEventListener('click', () => {
-							document.querySelector('#size-demo').setAttribute('size', 'xs');
+							document.querySelector('#size-demo').setAttribute('size', 'xsmall');
 							document.querySelector('#size-demo').show();
 						});
 						document.querySelector('#open-sm').addEventListener('click', () => {
-							document.querySelector('#size-demo').setAttribute('size', 'sm');
+							document.querySelector('#size-demo').setAttribute('size', 'small');
 							document.querySelector('#size-demo').show();
 						});
 						document.querySelector('#open-md').addEventListener('click', () => {
-							document.querySelector('#size-demo').setAttribute('size', 'md');
+							document.querySelector('#size-demo').setAttribute('size', 'medium');
 							document.querySelector('#size-demo').show();
 						});
 						document.querySelector('#open-lg').addEventListener('click', () => {
-							document.querySelector('#size-demo').setAttribute('size', 'lg');
+							document.querySelector('#size-demo').setAttribute('size', 'large');
 							document.querySelector('#size-demo').show();
 						});
 						document.querySelector('#open-xl').addEventListener('click', () => {
-							document.querySelector('#size-demo').setAttribute('size', 'xl');
+							document.querySelector('#size-demo').setAttribute('size', 'xlarge');
 							document.querySelector('#size-demo').show();
 						});
 						document.querySelector('#open-full').addEventListener('click', () => {
 							document.querySelector('#size-demo').setAttribute('size', 'full');
 							document.querySelector('#size-demo').show();
 						});
-						document.querySelector('#open-custom').addEventListener('click', () => {
-							const customSize = document.querySelector('#custom-size-input').value;
-							document.querySelector('#size-demo').setAttribute('size', customSize);
+						document.querySelector('#open-400').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', '400px');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-25-percent').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', '25%');
 							document.querySelector('#size-demo').show();
 						});
                     </script>
                 </template>
             </d2l-demo-snippet>
+
 			<h2>Prevent Closing</h2>
 			<d2l-demo-snippet>
 				<template>

--- a/demo/components/drawer/index.html
+++ b/demo/components/drawer/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href=/node_modules/@brightspace-ui/core/components/demo/styles.css type="text/css">
+        <script type="module">
+            import '@brightspace-ui/core/components/demo/demo-page.js';
+            import '@brightspace-ui/core/components/inputs/input-text.js';
+            import '@brightspace-ui/core/components/button/button.js';
+            import '../../../src/components/drawer/drawer.js';
+        </script>
+        <title>Drawer</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta charset="UTF-8">
+    </head>
+    <body>
+        <d2l-demo-page page-title="Drawer">
+            <h2>Drawer Positions</h2>
+            <d2l-demo-snippet>
+                <template>
+                    <d2l-button id="open-right">right</d2l-button>
+                    <d2l-button id="open-left">left</d2l-button>
+                    <d2l-button id="open-top">top</d2l-button>
+                    <d2l-button id="open-bottom">bottom</d2l-button>
+                    <d2l-labs-drawer id="position-right-demo" label="Demo Drawer" position="right">
+                        <div>
+                            <d2l-input-text id="nameId" label="Name" autofocus></d2l-input-text>
+                            <d2l-input-text id="descriptionId" label="Description"></d2l-input-text>
+                            <ul>
+                                <li>Lorem ipsum dolor sit amet</li>
+                                <li>consectetur adipiscing elit</li>
+                                <li>sed do eiusmod tempor incididunt</li>
+                            </ul>
+                        </div>
+                        <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+                        <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+                    </d2l-labs-drawer>
+					<d2l-labs-drawer id="position-left-demo" label="Demo Drawer" position="left">
+                        <div>
+                            <d2l-input-text id="nameId" label="Name" autofocus></d2l-input-text>
+                            <d2l-input-text id="descriptionId" label="Description"></d2l-input-text>
+                            <ul>
+                                <li>Lorem ipsum dolor sit amet</li>
+                                <li>consectetur adipiscing elit</li>
+                                <li>sed do eiusmod tempor incididunt</li>
+                            </ul>
+                        </div>
+                        <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+                        <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+                    </d2l-labs-drawer>
+					<d2l-labs-drawer id="position-top-demo" label="Demo Drawer" position="top">
+                        <div>
+                            <d2l-input-text id="nameId" label="Name" autofocus></d2l-input-text>
+                            <d2l-input-text id="descriptionId" label="Description"></d2l-input-text>
+                            <ul>
+                                <li>Lorem ipsum dolor sit amet</li>
+                                <li>consectetur adipiscing elit</li>
+                                <li>sed do eiusmod tempor incididunt</li>
+                            </ul>
+                        </div>
+                        <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+                        <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+                    </d2l-labs-drawer>
+					<d2l-labs-drawer id="position-bottom-demo" label="Demo Drawer" position="bottom">
+                        <div>
+                            <d2l-input-text id="nameId" label="Name" autofocus></d2l-input-text>
+                            <d2l-input-text id="descriptionId" label="Description"></d2l-input-text>
+                            <ul>
+                                <li>Lorem ipsum dolor sit amet</li>
+                                <li>consectetur adipiscing elit</li>
+                                <li>sed do eiusmod tempor incididunt</li>
+                            </ul>
+                        </div>
+                        <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+                        <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+                    </d2l-labs-drawer>
+                    <script>
+						document.querySelector('#open-right').addEventListener('click', () => {
+							document.querySelector('#position-right-demo').show();
+						});
+						document.querySelector('#open-left').addEventListener('click', () => {
+							document.querySelector('#position-left-demo').show();
+						});
+						document.querySelector('#open-top').addEventListener('click', () => {
+							document.querySelector('#position-top-demo').show();
+						});
+						document.querySelector('#open-bottom').addEventListener('click', () => {
+							document.querySelector('#position-bottom-demo').show();
+						});
+                    </script>
+                </template>
+            </d2l-demo-snippet>
+			<h2>Drawer Sizes</h2>
+            <d2l-demo-snippet>
+                <template>
+                    <d2l-button id="open-xs">xs</d2l-button>
+                    <d2l-button id="open-sm">sm</d2l-button>
+                    <d2l-button id="open-md">md</d2l-button>
+                    <d2l-button id="open-lg">lg</d2l-button>
+					<d2l-button id="open-xl">xl</d2l-button>
+					<d2l-button id="open-full">full</d2l-button>
+					<d2l-input-text id="custom-size-input" label="Custom Size Input" placeholder="% or px string"></d2l-input-text>
+					<d2l-button id="open-custom">Custom Size</d2l-button>
+                    <d2l-labs-drawer id="size-demo" label="Foobar">
+                        <div>
+                            <d2l-input-text id="nameId" label="Name" autofocus></d2l-input-text>
+                            <d2l-input-text id="descriptionId" label="Description"></d2l-input-text>
+                            <ul>
+                                <li>Lorem ipsum dolor sit amet</li>
+                                <li>consectetur adipiscing elit</li>
+                                <li>sed do eiusmod tempor incididunt</li>
+                            </ul>
+                        </div>
+                        <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+                        <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+                    </d2l-labs-drawer>
+                    <script>
+						document.querySelector('#open-xs').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', 'xs');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-sm').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', 'sm');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-md').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', 'md');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-lg').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', 'lg');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-xl').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', 'xl');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-full').addEventListener('click', () => {
+							document.querySelector('#size-demo').setAttribute('size', 'full');
+							document.querySelector('#size-demo').show();
+						});
+						document.querySelector('#open-custom').addEventListener('click', () => {
+							const customSize = document.querySelector('#custom-size-input').value;
+							document.querySelector('#size-demo').setAttribute('size', customSize);
+							document.querySelector('#size-demo').show();
+						});
+                    </script>
+                </template>
+            </d2l-demo-snippet>
+			<h2>Prevent Closing</h2>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-button id="openInterceptClosing">Show Drawer</d2l-button>
+					<d2l-labs-drawer id="drawerInterceptClosing" label="Prevent Closing">
+						<div>
+							<p>This drawer is prevented from closing by listening "d2l-drawer-before-close" event.</p>
+							<d2l-labs-drawer id="drawerConfirmClose" label="Comfirm close">
+								<div>
+									<p>Do you really want to close the previous drawer?</p>
+								</div>
+								<d2l-button slot="footer" primary data-dialog-action="confirm">Yes</d2l-button>
+								<d2l-button slot="footer" data-dialog-action="deny">No</d2l-button>
+							</d2l-drawer>
+						</div>
+						<d2l-button slot="footer" primary data-dialog-action="ok">Close Me!</d2l-button>
+						<d2l-button slot="footer" data-dialog-action="close">Close without confirmation</d2l-button>
+						<d2l-button slot="footer" data-dialog-action="cancel">Cancel</d2l-button>
+					</d2l-labs-drawer>
+					<script>
+						let canBeClosed = false;
+						document.querySelector('#openInterceptClosing').addEventListener('click', () => {
+							document.querySelector('#drawerInterceptClosing').show();
+						});
+						document.querySelector('#drawerInterceptClosing').addEventListener('d2l-drawer-open', () => {
+							canBeClosed = false;
+						});
+						document.querySelector('#drawerInterceptClosing').addEventListener('d2l-drawer-close', (e) => {
+							console.log('drawer action:', e.detail.action);
+						});
+						document.querySelector('#drawerConfirmClose').addEventListener('d2l-drawer-close', (e) => {
+							e.stopPropagation();
+						});
+						document.querySelector('#drawerInterceptClosing').addEventListener('d2l-drawer-before-close', async(e) => {
+
+							if (e.detail.action === 'close' || canBeClosed) return;
+
+							e.preventDefault();
+							const action = await document.querySelector('#drawerConfirmClose').show();
+
+							console.log('drawer action:', e.detail.action, ', confirm drawer action:', action);
+							if (action === 'confirm') {
+								canBeClosed = true;
+								e.detail.closeDrawer();
+							}
+						});
+					</script>
+				</template>
+			</d2l-demo-snippet>
+        </d2l-demo-page>
+    </body>
+</html>

--- a/helpers/localizeLabsElement.js
+++ b/helpers/localizeLabsElement.js
@@ -1,0 +1,11 @@
+import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
+
+export const LocalizeLabsElement = superclass => class extends LocalizeDynamicMixin(superclass) {
+
+	static get localizeConfig() {
+		return {
+			importFunc: async lang => (await import(`../src/lang/${lang}.js`)).default
+		};
+	}
+
+};

--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
 
 	<h1 class="d2l-heading-2">Demos</h1>
 
+	<h2 class="d2l-heading-3">Components</h2>
+	<ul>
+		<li><a href="demo/components/drawer/index.html">Drawer</a></li>
+	</ul>
+
 	<h2 class="d2l-heading-3">Controllers</h2>
 	<ul>
 		<li><a href="demo/controllers/computed-values/index.html">ComputedValues</a></li>

--- a/src/components/drawer/README.md
+++ b/src/components/drawer/README.md
@@ -1,0 +1,90 @@
+# @brightspaceui-labs/drawer
+
+> - [ ] [Design organization buy-in](https://daylight.d2l.dev/developing/creating-component/before-building/#working-with-design)
+> - [ ] [Architectural sign-off](https://daylight.d2l.dev/developing/creating-component/before-building/#web-component-architecture)
+> - [ ] [Continuous integration](https://daylight.d2l.dev/developing/testing/tools/#continuous-integration)
+> - [ ] [Cross-browser testing](https://daylight.d2l.dev/developing/testing/cross-browser/)
+> - [ ] [Unit tests](https://daylight.d2l.dev/developing/testing/tools/) (if applicable)
+> - [ ] [Accessibility tests](https://daylight.d2l.dev/developing/testing/accessibility/)
+> - [ ] [Visual diff tests](https://daylight.d2l.dev/developing/testing/visual-difference/)
+> - [ ] Localization with Serge (if applicable)
+> - [ ] Demo page
+> - [ ] README documentation
+
+Modal that is anchored to the edge of the viewport or parent container.
+
+## Usage
+
+```html
+<script type="module">
+  import '@brightspace-ui/core/components/button/button.js';
+  import '@brightspace-ui-labs/drawer/drawer.js';
+
+  document.querySelector('#open-demo').addEventListener('click', () => {
+    document.querySelector('#drawer-demo').show() = true;
+  });
+</script>
+<d2l-labs-drawer id="drawer-demo" title-text="Drawer Title">
+  <div>Some drawer content</div>
+  <d2l-button slot="footer" primary data-dialog-action="done">Done</d2l-button>
+  <d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+</d2l-labs-drawer>
+<d2l-button id="open-demo">Show Drawer</d2l-button>
+```
+
+**Notes & TODOs:**
+
+- Child drawers are non functional unless `position='right'`
+- Scroll height/component height does not respect default slot when footer slot content is present
+- `resize` mechanics require proper implementation
+- `lock-scroll` requires implementation
+- `trap-focus` requires implementation
+- `contained` requires implimentation
+- abort close animation requires attention
+  - event interception/preventDefault currently fires BOTH the pulse and the 'opening' animations
+  - need to integrate `prefers-reduced-motion`
+  - may want to have it be optional?
+-
+
+**Properties:**
+
+| Attribute | Description | Type | Default |
+| --------- | ----------- | ---- | ------- |
+| `contained` | **NOT IMPLIMENTED YET** By default, drawer will slide out from side of viewport. In order to slide out and be contained within parent element, must be set to true. (Parent element will also require `position: relative`) | `boolean` | `false` |
+| `lock-scroll`| **NOT IMPLIMENTED YET** Enables scroll lock if true  | `boolean`     | `false` |
+| `open`      | Reflects whether the drawer is open or closed (True when open)   | `boolean`     | `false` |
+| `position`  | Drawer body positioning, dictates which edge of the viewport or container the drawer will come out from  | `top` \| `bottom` \| `left` \| `right` \|  | `right` |
+| `size` | Controls drawer size. Can use predefined values or custom px/% inputs | `String` | `'md'` |
+| `trap-focus` | **NOT IMPLIMENTED YET** Trap client focus if true  | `boolean`     | `false` |
+| `hide-close-button` | Hides close button if false - can still be closed via escape key, a data-dialog-action, clicking outside the element - or using event hook | `boolean` | `true` |
+| `hide-header` | Hides header if false | `boolean` | `true` |
+
+**Accessibility:**
+
+To make your usage of `d2l-labs-drawer` accessible, use the following properties when applicable:
+
+| Attribute | Description | Type | Default |
+| --------- | ----------- | ---- | ------- |
+| `closeButtonLabel` | Close button aria-label | `string` | `'Close'` |
+| `label` | Drawer's label as displayed via aria/screenreader & title of header | `string` | `'Drawer'` |
+
+**Events:**
+
+| Name | Description |
+| --- | ---- |
+| `d2l-drawer-closed` | Emitted when drawer has closed and animations are complete |
+| `d2l-drawer-opened` | Emitted when drawer has opened and animations are complete |
+| `d2l-drawer-request-close` | Emitted when drawer close is requested - provides opportunity to prevent closure |
+
+**Slots:**
+| Name | Description |
+| ---- | ----------- |
+| `default` | Default slot for content within drawer |
+| `footer` | Slot for footer content such as workflow buttons, located at the bottom of drawer. Apply attribute `drawer-close` to workflow buttons to have them automatically close the drawer with the action's bound `value`. |
+
+**Methods:**
+| Name | Description |
+| ---- | ----------- |
+| `close()` | Closes the drawer |
+| `show()` | Shows the drawer |
+| `resize()` | Resize the drawer to custom size (preset term, px or %) |

--- a/src/components/drawer/README.md
+++ b/src/components/drawer/README.md
@@ -21,7 +21,7 @@ Modal that is anchored to the edge of the viewport or parent container.
   import '@brightspace-ui-labs/drawer/drawer.js';
 
   document.querySelector('#open-demo').addEventListener('click', () => {
-    document.querySelector('#drawer-demo').show() = true;
+    document.querySelector('#drawer-demo').show();
   });
 </script>
 <d2l-labs-drawer id="drawer-demo" title-text="Drawer Title">
@@ -37,6 +37,7 @@ Modal that is anchored to the edge of the viewport or parent container.
 - Child drawers are non functional unless `position='right'`
 - Scroll height/component height does not respect default slot when footer slot content is present
 - `resize` mechanics require proper implementation
+  - ex: % based custom sizes do not resize on window resize
 - `lock-scroll` requires implementation
 - `trap-focus` requires implementation
 - `contained` requires implimentation

--- a/src/components/drawer/README.md
+++ b/src/components/drawer/README.md
@@ -44,7 +44,7 @@ Modal that is anchored to the edge of the viewport or parent container.
   - event interception/preventDefault currently fires BOTH the pulse and the 'opening' animations
   - need to integrate `prefers-reduced-motion`
   - may want to have it be optional?
--
+- Swipe away to exit on mobile/touch
 
 **Properties:**
 

--- a/src/components/drawer/drawer-mixin.js
+++ b/src/components/drawer/drawer-mixin.js
@@ -1,4 +1,3 @@
-
 import '@brightspace-ui/core/components/focus-trap/focus-trap.js';
 import '@brightspace-ui/core/helpers/viewport-size.js';
 import { allowBodyScroll, preventBodyScroll } from '@brightspace-ui/core/components/backdrop/backdrop.js';

--- a/src/components/drawer/drawer-mixin.js
+++ b/src/components/drawer/drawer-mixin.js
@@ -16,7 +16,7 @@ window.D2L.DrawerMixin = window.D2L.DrawerMixin || {};
 
 const abortAction = 'abort';
 const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
-const presetSizes = { 'xs': 150, 'sm': 200, 'md': 300, 'lg': 400, 'xl': 500 };
+const presetSizes = { 'xsmall': 150, 'small': 200, 'medium': 300, 'large': 400, 'xlarge': 500 };
 
 /**
  * @fires d2l-drawer-close
@@ -50,7 +50,6 @@ export const DrawerMixin = superclass => class extends RtlMixin(superclass) {
 
 	constructor() {
 		super();
-		this.label = 'Drawer';
 		this.open = false;
 		this.position = 'right';
 		this._closeAborted = false;
@@ -76,24 +75,8 @@ export const DrawerMixin = superclass => class extends RtlMixin(superclass) {
 		}
 	}
 
-	close() {
-		if (!this.open) return;
-		this.open = false;
-		return new Promise(resolve => {
-			setTimeout(async() => {
-				await this._close();
-				resolve();
-			}, 0);
-		});
-	}
-
 	resize() {
-		return new Promise(resolve => {
-			setTimeout(async() => {
-				await this._updateSize();
-				resolve();
-			}, 0);
-		});
+		return this._updateSize();
 	}
 
 	show() {
@@ -315,8 +298,6 @@ export const DrawerMixin = superclass => class extends RtlMixin(superclass) {
 	}
 
 	_handleClose() {
-		/* reset state if native dialog closes unexpectedly. ex. user highlights
-        text and then hits escape key - this is not caught by our key handler */
 		this._removeHandlers();
 		this._focusOpener();
 		this._state = null;

--- a/src/components/drawer/drawer-mixin.js
+++ b/src/components/drawer/drawer-mixin.js
@@ -1,0 +1,510 @@
+
+import '@brightspace-ui/core/components/focus-trap/focus-trap.js';
+import '@brightspace-ui/core/helpers/viewport-size.js';
+import { allowBodyScroll, preventBodyScroll } from '@brightspace-ui/core/components/backdrop/backdrop.js';
+import { clearDismissible, setDismissible } from '@brightspace-ui/core/helpers/dismissible.js';
+import { findComposedAncestor, isComposedAncestor } from '@brightspace-ui/core/helpers/dom.js';
+import { forceFocusVisible, getComposedActiveElement, getNextFocusable, tryApplyFocus } from '@brightspace-ui/core/helpers/focus.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { styleMap } from 'lit/directives/style-map.js';
+
+window.D2L = window.D2L || {};
+window.D2L.DrawerMixin = window.D2L.DrawerMixin || {};
+
+const abortAction = 'abort';
+const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+const presetSizes = { 'xs': 150, 'sm': 200, 'md': 300, 'lg': 400, 'xl': 500 };
+
+/**
+ * @fires d2l-drawer-close
+ * @fires d2l-drawer-open
+ */
+export const DrawerMixin = superclass => class extends RtlMixin(superclass) {
+
+	static get properties() {
+		return {
+			/**
+             * Aria label for drawer component
+             */
+			label: { type: String },
+			/**
+             * Whether or not the drawer is open (true if drawer is open)
+             */
+			open: { type: Boolean, reflect: true },
+			/**
+             * Drawer body positiong (top, right, bottom, left)
+             */
+			position: { type: String, reflect: true },
+			_closeAborted: { type: Boolean }, // Still working on how to animate - may not need
+			_nestedShowing: { type: Boolean },
+			_overflowBottom: { type: Boolean },
+			_overflowTop: { type: Boolean },
+			_parentDrawer: { type: Object },
+			_scroll: { type: Boolean },
+			_state: { type: String, reflect: true },
+		};
+	}
+
+	constructor() {
+		super();
+		this.label = 'Drawer';
+		this.open = false;
+		this.position = 'right';
+		this._closeAborted = false;
+		this._drawerId = getUniqueId();
+		this._nestedShowing = false;
+		this._overflowBottom = false;
+		this._overflowTop = false;
+		this._parentDrawer = null;
+		this._scroll = false;
+		this._state = null;
+		this._updateSize = this._updateSize.bind(this);
+		this._updateOverflow = this._updateOverflow.bind(this);
+	}
+
+	async updated(changedProperties) {
+		super.updated(changedProperties);
+		if (!changedProperties.has('open')) return;
+
+		if (this.open) {
+			this._open();
+		} else {
+			this._close();
+		}
+	}
+
+	close() {
+		if (!this.open) return;
+		this.open = false;
+		return new Promise(resolve => {
+			setTimeout(async() => {
+				await this._close();
+				resolve();
+			}, 0);
+		});
+	}
+
+	resize() {
+		return new Promise(resolve => {
+			setTimeout(async() => {
+				await this._updateSize();
+				resolve();
+			}, 0);
+		});
+	}
+
+	show() {
+		if (this.open) return;
+		this.open = true;
+		return new Promise((resolve) => {
+			const onClose = function(e) {
+				if (e.target !== this) return; // ignore if bubbling from child drawer
+				this.removeEventListener('d2l-drawer-close', onClose);
+				resolve(e.detail.action);
+			}.bind(this);
+			this.addEventListener('d2l-drawer-close', onClose);
+		});
+	}
+
+	get _height() {
+		if (!this.shadowRoot) return null;
+
+		let availableHeight = window.innerHeight;
+
+		if (this.position === 'left' || this.position === 'right') {
+			return `${availableHeight}px`;
+		}
+
+		const parentRect = this._parentDrawer?.getBoundingClientRect();
+
+		if (parentRect) {
+			availableHeight -= Math.ceil(parentRect.height);
+		}
+
+		let preferredHeight = 0;
+
+		if (this.size in presetSizes) {
+			preferredHeight = presetSizes[this.size];
+		} else if (this.size === 'full') {
+			preferredHeight = window.innerHeight;
+		} else if (this.size.includes('%')) {
+			const preferredPercent = parseInt(this.size.split('%')[0]) / 100;
+			preferredHeight = Math.ceil(availableHeight * preferredPercent);
+		} else if (this.size.includes('px')) {
+			preferredHeight = parseInt(this.size.split('px')[0]);
+		}
+
+		return `${Math.min(preferredHeight, availableHeight)}px`;
+	}
+	// TODO: Make this truly unitless? Currently forces px or % on custom selections
+	get _width() {
+		if (!this.shadowRoot) return null;
+
+		let availableWidth = window.innerWidth;
+
+		if (this.position === 'top' || this.position === 'bottom') {
+			return `${availableWidth}px`;
+		}
+
+		const parentRect = this._parentDrawer?.getBoundingClientRect();
+
+		if (parentRect) {
+			availableWidth -= Math.ceil(parentRect.width);
+		}
+
+		let preferredWidth = 0;
+
+		if (this.size in presetSizes) {
+			preferredWidth = presetSizes[this.size];
+		} else if (this.size === 'full') {
+			preferredWidth = window.innerWidth; // Debatable if should just override parent or not
+		} else if (this.size.includes('%')) {
+			const preferredPercent = parseInt(this.size.split('%')[0]);
+			preferredWidth = Math.ceil(availableWidth * preferredPercent / 100);
+		} else if (this.size.includes('px')) {
+			preferredWidth = parseInt(this.size.split('px')[0]);
+		}
+
+		return `${Math.min(preferredWidth, availableWidth)}px`;
+	}
+	_addHandlers() {
+		window.addEventListener('resize', this._updateSize);
+		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-drawer-content').addEventListener('scroll', this._updateOverflow);
+	}
+
+	_close(action) {
+		if (!this._state) return;
+		this._action = action;
+
+		clearDismissible(this._dismissibleId);
+		this._dismissibleId = null;
+
+		if (!this.shadowRoot) return;
+		const drawer = this.shadowRoot.querySelector('.d2l-drawer-outer');
+
+		const doClose = () => {
+			this._handleClose();
+		};
+
+		if (this._isCloseAborted()) {
+			this._closeAborted = true;
+			// TODO: need to resolve how to run abort animation correctly
+			// as currently written, will run both the pulse AND open animations
+			// TODO: once properly implimented need to also run for 'prefer-reduced-motion'
+			// Don't actually need 'useAbortPulse', it's just here to prevent from showing right now
+			if (this._useAbortPulse) {
+				new Promise((resolve) => {
+					const animationEnd = () => {
+						drawer.removeEventListener('animationend', animationEnd);
+						drawer.style.animation = '';
+						resolve();
+					};
+					drawer.addEventListener('animationend', animationEnd);
+					drawer.style.animation = 'var(--d2l-drawer-pulse-animation) 400ms ease-in';
+				});
+			}
+
+			this._dismissibleId = setDismissible(() => this._close(abortAction));
+			return;
+		}
+
+		this._scroll = false;
+		if (!reduceMotion) {
+			const animationEnd = () => {
+				drawer.removeEventListener('animationend', animationEnd);
+				doClose();
+			};
+			drawer.addEventListener('animationend', animationEnd);
+			this._state = 'hiding';
+		} else {
+			this._state = 'hiding';
+			doClose();
+		}
+	}
+
+	_focusFirstChild() {
+		if (!this.shadowRoot) return;
+		const content = this.shadowRoot.querySelector('.d2l-drawer-content');
+		if (content) {
+			const firstFocusable = getNextFocusable(content);
+			if (isComposedAncestor(this.shadowRoot.querySelector('.d2l-drawer-inner'), firstFocusable)) {
+				forceFocusVisible(firstFocusable);
+				return;
+			}
+		}
+
+		const focusTrap = this.shadowRoot.querySelector('d2l-focus-trap');
+		if (focusTrap) {
+			focusTrap.focus();
+			return;
+		}
+
+		const footer = this.shadowRoot.querySelector('.d2l-drawer-footer');
+		if (footer) {
+			const firstFocusable = getNextFocusable(footer);
+			if (firstFocusable) forceFocusVisible(firstFocusable);
+		}
+	}
+
+	async _focusOpener() {
+		if (this._opener && this._opener.focus) {
+			// wait for inactive focus trap
+			requestAnimationFrame(() => {
+				tryApplyFocus(this._opener);
+				this._opener = null;
+			});
+		}
+	}
+
+	// Will likely need to swap logic for top/bottom to be more like how dialog works
+	// Where there is protected space for footer slot, and height is based on contents.
+	// But for the time being lets go with this...it may be better to be opinionated here.
+	//
+	// const availableHeight = this._ifrauContextInfo
+	//   ? this._ifrauContextInfo.availableHeight
+
+	// TODO: Account for parent + child being larger than the available area
+	// Could also collapse parent drawer to "minimum" state??
+	// if (value > availableWidth) {
+	//   This isn't really where this logic should live - it's more, of a `getEndPrimary` calculation
+	//     Logic is more like (value + primarySize) > availableWidth --> Trigger reduction
+	//   It does need to be done somewhere around here though if we're going to use getStart for css locating...
+	//   This likely means that we need a resize method on drawers so that children can request collapsing
+	//   TACKLE THIS AT SOME OTHER POINT!!!
+	//   Maybe just need to auto collapse parents always to some generic amount???
+	//   await - PARENT COLLAPSE SEQUENCE
+
+	//   const collapseParentWidth = this._parentDrawer?.getBoundingClientRect().width;
+	_getPositionBounds() {
+		if (!this.shadowRoot) return;
+
+		const position = `_${  this.position}`;
+		let value = 0;
+
+		const parentRect = this._parentDrawer?.getBoundingClientRect();
+
+		if (this.position === 'left' || this.position === 'right') {
+			value = !parentRect
+				? 0
+				: Math.ceil(parentRect.width);
+			this._top = 0;
+		} else if (this.position === 'top' || this.position === 'bottom') {
+			value = !parentRect
+				? 0
+				: Math.ceil(parentRect.height);
+			this._right = 0; // this is hack, likely just need css updated to properly expand to width/height
+		}
+
+		this[position] = value === 0 ? 0 : `${value}px`;
+	}
+
+	_handleBackdropClick() {
+		// if(!this._allowBackdropExit) return;
+		// ^ Unsure if this is a desirable trait - likely only need abort logic
+		this._close(abortAction);
+	}
+	_handleClick(e) {
+		// handle "dialog-action" for backwards-compatibility
+		if (!e.target.hasAttribute('data-dialog-action') && !e.target.hasAttribute('dialog-action')) return;
+		const action = e.target.getAttribute('data-dialog-action') || e.target.getAttribute('dialog-action');
+		e.stopPropagation();
+		this._close(action);
+	}
+
+	_handleClose() {
+		/* reset state if native dialog closes unexpectedly. ex. user highlights
+        text and then hits escape key - this is not caught by our key handler */
+		this._removeHandlers();
+		this._focusOpener();
+		this._state = null;
+		this.open = false;
+		allowBodyScroll(this._bodyScrollKey);
+		this._bodyScrollKey = null;
+		if (this._action === undefined || this._action === null) this._action = abortAction;
+		/** Dispatched with the bound action value when the drawer is closed for any reason */
+		this.dispatchEvent(new CustomEvent(
+			'd2l-drawer-close', {
+				bubbles: true,
+				composed: true,
+				detail: { action: this._action }
+			}
+		));
+	}
+
+	_handleDrawerClose(e) {
+		this._nestedShowing = false;
+		e.stopPropagation();
+	}
+
+	_handleDrawerOpen(e) {
+		this._nestedShowing = true;
+		e.stopPropagation();
+	}
+
+	_handleFocusTrapEnter(e) {
+		// ignore focus trap events when the target is another element
+		// to prevent infinite focus loops
+		if (e.target !== this) return;
+		this._focusFirstChild();
+	}
+
+	_handleKeyDown(e) {
+		if (!this.open) return;
+		if (e.keyCode === 27) {
+			// escape (note: prevent native close so we can animate it; use setDismissible)
+			e.preventDefault();
+		}
+	}
+
+	_isCloseAborted() {
+		const abortEvent = new CustomEvent('d2l-drawer-before-close', {
+			cancelable: true,
+			detail: {
+				action: this._action,
+				closeDrawer: this._close.bind(this, this._action)
+			}
+		});
+		this.dispatchEvent(abortEvent);
+
+		return abortEvent.defaultPrevented;
+	}
+
+	_open() {
+		this._opener = getComposedActiveElement();
+		this._dismissibleId = setDismissible(() => {
+			this._close(abortAction);
+		});
+
+		this._action = undefined;
+		this._addHandlers();
+
+		if (!this.shadowRoot) return;
+		const drawer = this.shadowRoot.querySelector('.d2l-drawer-outer');
+
+		const animationPromise = new Promise((resolve) => {
+			const animationEnd = () => {
+				drawer.removeEventListener('animationend', animationEnd);
+				resolve();
+			};
+			drawer.addEventListener('animationend', animationEnd);
+		});
+
+		this._parentDrawer = findComposedAncestor(this, (node) => {
+			return node.classList && node.classList.contains('d2l-drawer-outer');
+		});
+
+		// TODO: Base this functionality off of scolllock property
+		this._bodyScrollKey = preventBodyScroll();
+
+		this._focusFirstChild();
+
+		setTimeout(async() => {
+
+			this.shadowRoot.querySelector('.d2l-drawer-content').scrollTop = 0;
+			// scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash
+			setTimeout(() => {
+				this._scroll = true;
+			}, 0);
+
+			// TODO: Skipping update size for now, must revisit!
+			await this._updateSize();
+			this._state = 'showing';
+			await this._updateComplete;
+
+			// edge case: no children were focused, try again after one redraw
+			const activeElement = getComposedActiveElement();
+			if (!activeElement
+            || !isComposedAncestor(drawer, activeElement)
+            || !activeElement.classList.contains('focus-visible')) {
+				this._focusFirstChild();
+			}
+
+			if (!reduceMotion) await animationPromise;
+			/** Dispatched when the drawer is opened */
+			this.dispatchEvent(new CustomEvent(
+				'd2l-drawer-open', { bubbles: true, composed: true }
+			));
+		}, 0);
+
+	}
+
+	_removeHandlers() {
+		window.removeEventListener('resize', this._updateSize);
+		if (this.shadowRoot) this.shadowRoot.querySelector('.d2l-drawer-content').removeEventListener('scroll', this._updateOverflow);
+	}
+
+	_render(inner, info) {
+		// ignored all style stuff from prev --> styles.top, etc.
+		// ignoring iframe stuff for now
+		const closeAnimation = `d2l-drawer-close-${this.position}`;
+		const openAnimation = `d2l-drawer-open-${this.position}`;
+
+		const styles = {
+			'--d2l-drawer-close-animation': closeAnimation,
+			'--d2l-drawer-open-animation': openAnimation,
+		};
+
+		if (this._height) styles.height = `${this._height}`;
+		if (this._width) styles.width = `${this._width}`;
+		if (this._top !== undefined) styles.top = `${this._top}`;
+		if (this._bottom !== undefined) styles.bottom = `${this._bottom}`;
+		if (this._right !== undefined) styles.right = `${this._right}`;
+		if (this._left !== undefined) styles.left = `${this._left}`;
+
+		const drawerOuterClasses = {
+			'd2l-drawer-outer': true,
+			'd2l-drawer-outer-nested': this._parentDrawer,
+			'd2l-drawer-outer-nested-showing': this._nestedShowing,
+			'd2l-drawer-outer-scroll': this._scroll,
+			'd2l-drawer-fullscreen': this._size === 'full',
+		};
+
+		// TODO: Play with no focus-trap + no backdrop
+		return html`
+            <div
+                aria-describedby=${ifDefined(info.descId)}
+                aria-labelledby=${info.labelId}
+                class=${classMap(drawerOuterClasses)}
+                @click=${this._handleClick}
+                @d2l-drawer-close=${this._handleDrawerClose}
+                @d2l-drawer-open=${this._handleDrawerOpen}
+                id=${this._drawerId}
+                role=${info.role}
+                style=${styleMap(styles)}>
+                <d2l-focus-trap
+                    @d2l-focus-trap-enter=${this._handleFocusTrapEnter}
+                    ?trap=${this.open && this.trapFocus}>
+                    ${inner}
+                </d2l-focus-trap>
+            </div>
+            <d2l-backdrop
+                for-target=${this._drawerId}
+                ?shown=${this._state === 'showing'}
+                @click=${this._handleBackdropClick}
+                tabindex="-1">
+            </d2l-backdrop>`;
+	}
+
+	_updateOverflow() {
+		if (!this.shadowRoot) return;
+		const content = this.shadowRoot.querySelector('.d2l-drawer-content');
+		this._overflowTop = (content.scrollTop > 0);
+		this._overflowBottom = (content.scrollHeight > content.scrollTop + content.clientHeight);
+	}
+
+	async _updateSize() {
+		this._getPositionBounds();
+		await this.updateComplete;
+		await new Promise(resolve => {
+			requestAnimationFrame(async() => {
+				this._updateOverflow();
+				await this.updateComplete;
+				resolve();
+			});
+		});
+	}
+};

--- a/src/components/drawer/drawer-styles.js
+++ b/src/components/drawer/drawer-styles.js
@@ -1,0 +1,216 @@
+
+import '@brightspace-ui/core/components/colors/colors.js';
+import { css } from 'lit';
+
+export const drawerStyles = css`
+
+    :host {
+        --d2l-drawer-background-color: white;
+        --d2l-drawer-border-color: var(--d2l-color-mica);
+        --d2l-drawer-pulse-animation: d2l-drawer-pulse;
+
+        display: none;
+    }
+
+    :host([open]),
+    :host([_state="showing"]),
+    :host([_state="hiding"]) {
+        display: block;
+    }
+
+    :host([open]:not([_state="showing"])) {
+        visibility: hidden;
+    }
+
+    :host([open][_state="showing"]),
+    :host([open][_state="hiding"]) {
+        visibility: visible;
+    }
+
+    .d2l-drawer-outer {
+        animation: var(--d2l-drawer-close-animation) 200ms ease-in;
+        background-color: var(--d2l-drawer-background-color);
+        box-sizing: border-box;
+        position: fixed;
+        z-index: 1000;
+    }
+
+    d2l-focus-trap {
+        display: block;
+        height: 100%;
+        width: 100%;
+    }
+
+    .d2l-drawer-inner {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        width: 100%;
+    }
+
+    d2l-backdrop {
+        background-color: var(--d2l-color-ferrite);
+    }
+
+    /* Positioning styles based on consumer preference */
+
+    :host([position="right"]) > .d2l-drawer-outer {
+        box-shadow: -5px 0px 10px -2px rgba(0, 0, 0, 0.1);
+        border-left: 1px solid var(--d2l-drawer-border-color);
+    }
+
+    :host([position="top"]) > .d2l-drawer-outer {
+        box-shadow: -5px 0px 10px -2px rgba(0, 0, 0, 0.1);
+        border-left: 1px solid var(--d2l-drawer-border-color);
+    }
+
+    .d2l-drawer-content {
+        box-sizing: border-box;
+        flex: 1 0 0; /* TODO: Have this be toggleable, so that footer can pop up to bottom of content */
+        overflow: hidden; /* scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash */
+        padding: 0 1.2rem;
+    }
+
+    /* WIP - Playing with "closeAborted" animation - WIP
+	:host([_closeAborted][_state="showing"]) > .d2l-drawer-outer {
+		animation: var(--d2l-drawer-pulse-animation) 400ms ease-in;
+	} */
+
+    /* Animation related states */
+    :host([_state="showing"]) > .d2l-drawer-outer {
+        /* must target direct child to avoid ancestor from interfering with closing child drawers in Legacy-Edge */
+        animation: var(--d2l-drawer-open-animation) 250ms ease-out;
+    }
+
+    /* close, open, and pulse animations */
+    /*  Possibly "overslide" by 5% or something, is this anti d2l-pattern? */
+
+    @keyframes d2l-drawer-close-top {
+        0% { transform: translateY(0); }
+        100% { transform: translateY(-100%); }
+    }
+
+    @keyframes d2l-drawer-open-top {
+        0% { transform: translateY(-75%); }
+        100% { transform: translateY(0); }
+    }
+
+    @keyframes d2l-drawer-close-right {
+        0% { transform: translateX(0); }
+        100% { transform: translateX(100%); }
+    }
+
+    @keyframes d2l-drawer-open-right {
+        0% { transform: translateX(75%); }
+        100% { transform: translateX(0); }
+    }
+
+    @keyframes d2l-drawer-close-bottom {
+        0% { transform: translateY(0); }
+        100% { transform: translateY(100%); }
+    }
+
+    @keyframes d2l-drawer-open-bottom {
+        0% { transform: translateY(75%); }
+        100% { transform: translateY(0); }
+    }
+
+    @keyframes d2l-drawer-close-left {
+        0% { transform: translateX(0); }
+        100% { transform: translateX(-100%); }
+    }
+
+    @keyframes d2l-drawer-open-left {
+        0% { transform: translateX(-75%); }
+        100% { transform: translateX(0); }
+    }
+
+    /* Approx duration ~400ms */
+    @keyframes d2l-drawer-pulse {
+        0% { transform: scale(1); }
+        50% { transform: scale(1.03); }
+        100% { transform: scale(1); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .d2l-drawer-outer,
+        :host([_state="showing"]) > .d2l-drawer-outer {
+            animation: none;
+        }
+    }
+
+`;
+
+export const drawerHeaderStyles = css`
+
+    .d2l-drawer-header {
+        box-sizing: border-box;
+        padding: 0.6rem 1.2rem 0.6rem 1.2rem;
+    }
+
+    .d2l-drawer-header > div {
+        display: flex;
+    }
+
+    .d2l-drawer-header > div > h2 {
+        flex: 1 0 0;
+        margin: 0;
+        align-self: center;
+    }
+
+    @media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+        .d2l-drawer-header {
+            padding: 14px 20px 16px 20px;
+        }
+        .d2l-drawer-fullscreen .d2l-drawer-header > div > d2l-button-icon {
+            margin: -8px -13px 0 15px;
+        }
+        :host([dir="rtl"]) .d2l-drawer-fullscreen .d2l-drawer-header > div > d2l-button-icon {
+            margin-left: -13px;
+            margin-right: 15px;
+        }
+    }
+`;
+
+export const drawerFooterStyles = css`
+
+    .d2l-drawer-footer {
+        box-sizing: border-box;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        align-items: center;
+        justify-content: flex-end;
+        padding: 0.6rem 1.2rem 1.2rem 1.2rem;
+    } /* Better setup for actions would be cool */
+
+    @media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+        .d2l-drawer-footer {
+            padding: 0.6rem 1.2rem 1.2rem 1.2rem; /* Need to update */
+        }
+    }
+`;
+
+export const otherStyles = css`
+
+    .d2l-drawer-outer-scroll .d2l-drawer-content {
+        overflow: auto;
+    }
+
+    div.d2l-drawer-outer.d2l-drawer-fullscreen {
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        height: 100% !important;
+        top: 0;
+        width: 100% !important;
+    }
+
+    @media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+        .d2l-drawer-outer.d2l-drawer-fullscreen {
+            margin: 0 !important;
+            min-width: calc(var(--d2l-vw, 1vw) * 100);
+            top: 42px;
+        }
+    }
+`;

--- a/src/components/drawer/drawer-styles.js
+++ b/src/components/drawer/drawer-styles.js
@@ -28,7 +28,6 @@ export const drawerStyles = css`
 	}
 
 	.d2l-drawer-outer {
-		animation: var(--d2l-drawer-close-animation) 200ms ease-in;
 		background-color: var(--d2l-drawer-background-color);
 		box-sizing: border-box;
 		position: fixed;
@@ -71,15 +70,15 @@ export const drawerStyles = css`
 		padding: 0 1.2rem;
 	}
 
-	/* WIP - Playing with "closeAborted" animation - WIP
-	:host([_closeAborted][_state="showing"]) > .d2l-drawer-outer {
-		animation: var(--d2l-drawer-pulse-animation) 400ms ease-in;
-	} */
-
 	/* Animation related states */
-	:host([_state="showing"]) > .d2l-drawer-outer {
-		/* must target direct child to avoid ancestor from interfering with closing child drawers in Legacy-Edge */
-		animation: var(--d2l-drawer-open-animation) 250ms ease-out;
+	@media (prefers-reduced-motion: no-preference) {
+		.d2l-drawer-outer {
+			animation: var(--d2l-drawer-close-animation) 200ms ease-in;
+		}
+
+		:host([_state="showing"]) > .d2l-drawer-outer {
+			animation: var(--d2l-drawer-open-animation) 250ms ease-out;
+		}
 	}
 
 	/* close, open, and pulse animations */

--- a/src/components/drawer/drawer-styles.js
+++ b/src/components/drawer/drawer-styles.js
@@ -4,213 +4,213 @@ import { css } from 'lit';
 
 export const drawerStyles = css`
 
-    :host {
-        --d2l-drawer-background-color: white;
-        --d2l-drawer-border-color: var(--d2l-color-mica);
-        --d2l-drawer-pulse-animation: d2l-drawer-pulse;
+	:host {
+		--d2l-drawer-background-color: white;
+		--d2l-drawer-border-color: var(--d2l-color-mica);
+		--d2l-drawer-pulse-animation: d2l-drawer-pulse;
 
-        display: none;
-    }
+		display: none;
+	}
 
-    :host([open]),
-    :host([_state="showing"]),
-    :host([_state="hiding"]) {
-        display: block;
-    }
+	:host([open]),
+	:host([_state="showing"]),
+	:host([_state="hiding"]) {
+		display: block;
+	}
 
-    :host([open]:not([_state="showing"])) {
-        visibility: hidden;
-    }
+	:host([open]:not([_state="showing"])) {
+		visibility: hidden;
+	}
 
-    :host([open][_state="showing"]),
-    :host([open][_state="hiding"]) {
-        visibility: visible;
-    }
+	:host([open][_state="showing"]),
+	:host([open][_state="hiding"]) {
+		visibility: visible;
+	}
 
-    .d2l-drawer-outer {
-        animation: var(--d2l-drawer-close-animation) 200ms ease-in;
-        background-color: var(--d2l-drawer-background-color);
-        box-sizing: border-box;
-        position: fixed;
-        z-index: 1000;
-    }
+	.d2l-drawer-outer {
+		animation: var(--d2l-drawer-close-animation) 200ms ease-in;
+		background-color: var(--d2l-drawer-background-color);
+		box-sizing: border-box;
+		position: fixed;
+		z-index: 1000;
+	}
 
-    d2l-focus-trap {
-        display: block;
-        height: 100%;
-        width: 100%;
-    }
+	d2l-focus-trap {
+		display: block;
+		height: 100%;
+		width: 100%;
+	}
 
-    .d2l-drawer-inner {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-        width: 100%;
-    }
+	.d2l-drawer-inner {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		width: 100%;
+	}
 
-    d2l-backdrop {
-        background-color: var(--d2l-color-ferrite);
-    }
+	d2l-backdrop {
+		background-color: var(--d2l-color-ferrite);
+	}
 
-    /* Positioning styles based on consumer preference */
+	/* Positioning styles based on consumer preference */
 
-    :host([position="right"]) > .d2l-drawer-outer {
-        box-shadow: -5px 0px 10px -2px rgba(0, 0, 0, 0.1);
-        border-left: 1px solid var(--d2l-drawer-border-color);
-    }
+	:host([position="right"]) > .d2l-drawer-outer {
+		border-left: 1px solid var(--d2l-drawer-border-color);
+		box-shadow: -5px 0 10px -2px rgba(0, 0, 0, 0.1);
+	}
 
-    :host([position="top"]) > .d2l-drawer-outer {
-        box-shadow: -5px 0px 10px -2px rgba(0, 0, 0, 0.1);
-        border-left: 1px solid var(--d2l-drawer-border-color);
-    }
+	:host([position="top"]) > .d2l-drawer-outer {
+		border-left: 1px solid var(--d2l-drawer-border-color);
+		box-shadow: -5px 0 10px -2px rgba(0, 0, 0, 0.1);
+	}
 
-    .d2l-drawer-content {
-        box-sizing: border-box;
-        flex: 1 0 0; /* TODO: Have this be toggleable, so that footer can pop up to bottom of content */
-        overflow: hidden; /* scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash */
-        padding: 0 1.2rem;
-    }
+	.d2l-drawer-content {
+		box-sizing: border-box;
+		flex: 1 0 0; /* TODO: Have this be toggleable, so that footer can pop up to bottom of content */
+		overflow: hidden; /* scrollbar is kept hidden while we update the scroll position to avoid scrollbar flash */
+		padding: 0 1.2rem;
+	}
 
-    /* WIP - Playing with "closeAborted" animation - WIP
+	/* WIP - Playing with "closeAborted" animation - WIP
 	:host([_closeAborted][_state="showing"]) > .d2l-drawer-outer {
 		animation: var(--d2l-drawer-pulse-animation) 400ms ease-in;
 	} */
 
-    /* Animation related states */
-    :host([_state="showing"]) > .d2l-drawer-outer {
-        /* must target direct child to avoid ancestor from interfering with closing child drawers in Legacy-Edge */
-        animation: var(--d2l-drawer-open-animation) 250ms ease-out;
-    }
+	/* Animation related states */
+	:host([_state="showing"]) > .d2l-drawer-outer {
+		/* must target direct child to avoid ancestor from interfering with closing child drawers in Legacy-Edge */
+		animation: var(--d2l-drawer-open-animation) 250ms ease-out;
+	}
 
-    /* close, open, and pulse animations */
-    /*  Possibly "overslide" by 5% or something, is this anti d2l-pattern? */
+	/* close, open, and pulse animations */
+	/*  Possibly "overslide" by 5% or something, is this anti d2l-pattern? */
 
-    @keyframes d2l-drawer-close-top {
-        0% { transform: translateY(0); }
-        100% { transform: translateY(-100%); }
-    }
+	@keyframes d2l-drawer-close-top {
+		0% { transform: translateY(0); }
+		100% { transform: translateY(-100%); }
+	}
 
-    @keyframes d2l-drawer-open-top {
-        0% { transform: translateY(-75%); }
-        100% { transform: translateY(0); }
-    }
+	@keyframes d2l-drawer-open-top {
+		0% { transform: translateY(-75%); }
+		100% { transform: translateY(0); }
+	}
 
-    @keyframes d2l-drawer-close-right {
-        0% { transform: translateX(0); }
-        100% { transform: translateX(100%); }
-    }
+	@keyframes d2l-drawer-close-right {
+		0% { transform: translateX(0); }
+		100% { transform: translateX(100%); }
+	}
 
-    @keyframes d2l-drawer-open-right {
-        0% { transform: translateX(75%); }
-        100% { transform: translateX(0); }
-    }
+	@keyframes d2l-drawer-open-right {
+		0% { transform: translateX(75%); }
+		100% { transform: translateX(0); }
+	}
 
-    @keyframes d2l-drawer-close-bottom {
-        0% { transform: translateY(0); }
-        100% { transform: translateY(100%); }
-    }
+	@keyframes d2l-drawer-close-bottom {
+		0% { transform: translateY(0); }
+		100% { transform: translateY(100%); }
+	}
 
-    @keyframes d2l-drawer-open-bottom {
-        0% { transform: translateY(75%); }
-        100% { transform: translateY(0); }
-    }
+	@keyframes d2l-drawer-open-bottom {
+		0% { transform: translateY(75%); }
+		100% { transform: translateY(0); }
+	}
 
-    @keyframes d2l-drawer-close-left {
-        0% { transform: translateX(0); }
-        100% { transform: translateX(-100%); }
-    }
+	@keyframes d2l-drawer-close-left {
+		0% { transform: translateX(0); }
+		100% { transform: translateX(-100%); }
+	}
 
-    @keyframes d2l-drawer-open-left {
-        0% { transform: translateX(-75%); }
-        100% { transform: translateX(0); }
-    }
+	@keyframes d2l-drawer-open-left {
+		0% { transform: translateX(-75%); }
+		100% { transform: translateX(0); }
+	}
 
-    /* Approx duration ~400ms */
-    @keyframes d2l-drawer-pulse {
-        0% { transform: scale(1); }
-        50% { transform: scale(1.03); }
-        100% { transform: scale(1); }
-    }
+	/* Approx duration ~400ms */
+	@keyframes d2l-drawer-pulse {
+		0% { transform: scale(1); }
+		50% { transform: scale(1.03); }
+		100% { transform: scale(1); }
+	}
 
-    @media (prefers-reduced-motion: reduce) {
-        .d2l-drawer-outer,
-        :host([_state="showing"]) > .d2l-drawer-outer {
-            animation: none;
-        }
-    }
+	@media (prefers-reduced-motion: reduce) {
+		.d2l-drawer-outer,
+		:host([_state="showing"]) > .d2l-drawer-outer {
+			animation: none;
+		}
+	}
 
 `;
 
 export const drawerHeaderStyles = css`
 
-    .d2l-drawer-header {
-        box-sizing: border-box;
-        padding: 0.6rem 1.2rem 0.6rem 1.2rem;
-    }
+	.d2l-drawer-header {
+		box-sizing: border-box;
+		padding: 0.6rem 1.2rem 0.6rem 1.2rem;
+	}
 
-    .d2l-drawer-header > div {
-        display: flex;
-    }
+	.d2l-drawer-header > div {
+		display: flex;
+	}
 
-    .d2l-drawer-header > div > h2 {
-        flex: 1 0 0;
-        margin: 0;
-        align-self: center;
-    }
+	.d2l-drawer-header > div > h2 {
+		align-self: center;
+		flex: 1 0 0;
+		margin: 0;
+	}
 
-    @media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-        .d2l-drawer-header {
-            padding: 14px 20px 16px 20px;
-        }
-        .d2l-drawer-fullscreen .d2l-drawer-header > div > d2l-button-icon {
-            margin: -8px -13px 0 15px;
-        }
-        :host([dir="rtl"]) .d2l-drawer-fullscreen .d2l-drawer-header > div > d2l-button-icon {
-            margin-left: -13px;
-            margin-right: 15px;
-        }
-    }
+	@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+		.d2l-drawer-header {
+			padding: 14px 20px 16px 20px;
+		}
+		.d2l-drawer-fullscreen .d2l-drawer-header > div > d2l-button-icon {
+			margin: -8px -13px 0 15px;
+		}
+		:host([dir="rtl"]) .d2l-drawer-fullscreen .d2l-drawer-header > div > d2l-button-icon {
+			margin-left: -13px;
+			margin-right: 15px;
+		}
+	}
 `;
 
 export const drawerFooterStyles = css`
 
-    .d2l-drawer-footer {
-        box-sizing: border-box;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.6rem;
-        align-items: center;
-        justify-content: flex-end;
-        padding: 0.6rem 1.2rem 1.2rem 1.2rem;
-    } /* Better setup for actions would be cool */
+	.d2l-drawer-footer {
+		align-items: center;
+		box-sizing: border-box;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+		justify-content: flex-end;
+		padding: 0.6rem 1.2rem 1.2rem 1.2rem;
+	} /* Better setup for actions would be cool */
 
-    @media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-        .d2l-drawer-footer {
-            padding: 0.6rem 1.2rem 1.2rem 1.2rem; /* Need to update */
-        }
-    }
+	@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+		.d2l-drawer-footer {
+			padding: 0.6rem 1.2rem 1.2rem 1.2rem; /* Need to update */
+		}
+	}
 `;
 
 export const otherStyles = css`
 
-    .d2l-drawer-outer-scroll .d2l-drawer-content {
-        overflow: auto;
-    }
+	.d2l-drawer-outer-scroll .d2l-drawer-content {
+		overflow: auto;
+	}
 
-    div.d2l-drawer-outer.d2l-drawer-fullscreen {
-        border: none;
-        border-radius: 0;
-        box-shadow: none;
-        height: 100% !important;
-        top: 0;
-        width: 100% !important;
-    }
+	div.d2l-drawer-outer.d2l-drawer-fullscreen {
+		border: none;
+		border-radius: 0;
+		box-shadow: none;
+		height: 100% !important;
+		top: 0;
+		width: 100% !important;
+	}
 
-    @media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
-        .d2l-drawer-outer.d2l-drawer-fullscreen {
-            margin: 0 !important;
-            min-width: calc(var(--d2l-vw, 1vw) * 100);
-            top: 42px;
-        }
-    }
+	@media (max-width: 615px), (max-height: 420px) and (max-width: 900px) {
+		.d2l-drawer-outer.d2l-drawer-fullscreen {
+			margin: 0 !important;
+			min-width: calc(var(--d2l-vw, 1vw) * 100);
+			top: 42px;
+		}
+	}
 `;

--- a/src/components/drawer/drawer.js
+++ b/src/components/drawer/drawer.js
@@ -31,14 +31,15 @@ class Drawer extends LocalizeLabsElement(DrawerMixin(LitElement)) {
              */
 			lockScroll: { type: Boolean, attribute: 'lock-scroll', reflect: true },
 			/**
-             * Control drawer size. Can use predefined values (sm, md, lg, full), or set drawer body size with any px or % values
+             * Can use predefined values (xsmall, small, medium, large, xlarge,
+			 * full) or set drawer body size with any px or % values
              * Controls width for left and right positions and height for top and bottom.
              */
 			size: { type: String },
 			/**
              * Trap user focus if true
              */
-			trapFocus: { type: Boolean, reflect: true },
+			trapFocus: { type: Boolean, reflect: true, attribute: 'trap-focus' },
 			/**
              * Hides close button if true, can still be closed via escape key or clicking out
              */
@@ -60,7 +61,7 @@ class Drawer extends LocalizeLabsElement(DrawerMixin(LitElement)) {
 		this.hideCloseButton = false;
 		this.hideHeader = false;
 		this.lockScroll = true;
-		this.size = 'md';
+		this.size = 'medium';
 		this.trapFocus = true;
 		this._hasFooterContent = false;
 		this._handleResize = this._handleResize.bind(this);

--- a/src/components/drawer/drawer.js
+++ b/src/components/drawer/drawer.js
@@ -1,0 +1,162 @@
+
+import '@brightspace-ui/core/components/button/button-icon.js';
+
+import { drawerFooterStyles, drawerHeaderStyles, drawerStyles } from './drawer-styles.js';
+import { html, LitElement, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { DrawerMixin } from './drawer-mixin.js';
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+import { heading3Styles } from '@brightspace-ui/core/components/typography/styles.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { LocalizeLabsElement } from '../../../helpers/localizeLabsElement.js';
+
+const mediaQueryList = window.matchMedia('(max-width: 615px), (max-height: 420px) and (max-width: 900px)');
+
+/**
+ * Modal element that is anchored to one side of the viewport or parent element.
+ * @fires d2l-drawer-before-close - Dispatched with bound action value before the dialog is closed for any reason, providing an opportunity to prevent the closing.
+ * @slot - Default slot for content inside drawer
+ * @slot footer - Slot for footer content such as workflow buttons. Apply attribute `drawer-close` to workflow buttons to have them automatically close the drawer with the action's bound `value`.
+ */
+class Drawer extends LocalizeLabsElement(DrawerMixin(LitElement)) {
+
+	static get properties() {
+		return {
+			/**
+             * Aria label for default provided close button
+             */
+			closeButtonLabel: { type: String, attribute: 'close-button-label' },
+			/**
+             * Disables scroll locking if true
+             */
+			lockScroll: { type: Boolean, attribute: 'lock-scroll', reflect: true },
+			/**
+             * Control drawer size. Can use predefined values (sm, md, lg, full), or set drawer body size with any px or % values
+             * Controls width for left and right positions and height for top and bottom.
+             */
+			size: { type: String },
+			/**
+             * Trap user focus if true
+             */
+			trapFocus: { type: Boolean, reflect: true },
+			/**
+             * Hides close button if true, can still be closed via escape key or clicking out
+             */
+			hideCloseButton: { type: Boolean, attribute: 'hide-close-button' },
+			/**
+             * Hides header if true
+             */
+			hideHeader: { type: Boolean, attribute: 'hide-header' },
+			_hasFooterContent: { type: Boolean, attribute: false },
+		};
+	}
+
+	static get styles() {
+		return [ drawerStyles, drawerHeaderStyles, drawerFooterStyles, heading3Styles ];
+	}
+
+	constructor() {
+		super();
+		this.hideCloseButton = false;
+		this.hideHeader = false;
+		this.lockScroll = true;
+		this.size = 'md';
+		this.trapFocus = true;
+		this._hasFooterContent = false;
+		this._handleResize = this._handleResize.bind(this);
+		this._labelId = undefined;
+		this._textId = undefined;
+	}
+
+	get closeButton() {
+		return !this.hideCloseButton
+			? html`
+                <d2l-button-icon
+                    id="drawer-default-close"
+                    icon="tier1:close-small"
+                    text="${this.localize('components.drawer.close')}"
+                    @click=${this._abort}
+                    tabindex=100>
+                </d2l-button-icon>`
+			: nothing;
+	}
+	get content() {
+		if (!this._textId && this.describeContent) this._textId = getUniqueId();
+
+		return html`
+            <div id=${ifDefined(this._textId)}>
+                <slot></slot>
+            </div>`;
+	}
+	get header() {
+		if (!this._labelId) this._labelId = getUniqueId();
+
+		return !this.hideHeader
+			? html`
+                <div class="d2l-drawer-header">
+                    <div>
+                        <h2 id=${this._labelId} class="d2l-heading-3">${this.label}</h2>
+                        ${this.closeButton}
+                    </div>
+                </div>`
+			: nothing;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		if (mediaQueryList.addEventListener) mediaQueryList.addEventListener('change', this._handleResize);
+	}
+
+	disconnectedCallback() {
+		if (mediaQueryList.removeEventListener) mediaQueryList.removeEventListener('change', this._handleResize);
+		super.disconnectedCallback();
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		this._handleResize();
+	}
+
+	render() {
+		const footerClasses = {
+			'd2l-drawer-footer': true,
+			'd2l-footer-no-content': !this._hasFooterContent
+		};
+
+		const inner = html`
+            <div class="d2l-drawer-inner">
+                ${this.header}
+                <div class="d2l-drawer-content">${this.content}</div>
+                <div class=${classMap(footerClasses)}>
+                    <slot name="footer" @slotchange=${this._handleFooterSlotChange}></slot>
+                </div>
+            </div>
+        `;
+
+		const descId = (this.describeContent) ? this._textId : undefined;
+		return this._render(
+			inner,
+			{
+				descId: descId,
+				labelId: this._labelId,
+				role: 'dialog'
+			}
+		);
+	}
+
+	_abort() {
+		this._close('abort');
+	}
+
+	_handleFooterSlotChange(e) {
+		const footerContent = e.target.assignedNodes({ flatten: true });
+		this._hasFooterContent = (footerContent && footerContent.length > 0);
+	}
+
+	_handleResize() {
+		this._autoSize = !mediaQueryList.matches;
+		// this.resize();
+	}
+
+}
+customElements.define('d2l-labs-drawer', Drawer);

--- a/src/components/drawer/drawer.js
+++ b/src/components/drawer/drawer.js
@@ -27,7 +27,7 @@ class Drawer extends LocalizeLabsElement(DrawerMixin(LitElement)) {
              */
 			closeButtonLabel: { type: String, attribute: 'close-button-label' },
 			/**
-             * Disables scroll locking if true
+             * Enables scroll locking of parent content if true
              */
 			lockScroll: { type: Boolean, attribute: 'lock-scroll', reflect: true },
 			/**

--- a/src/lang/.eslintrc.json
+++ b/src/lang/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [{
+    "files": [
+      "**/*.js"
+    ],
+    "rules": {
+      "quotes": 0
+    }
+  }]
+}

--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/cy.js
+++ b/src/lang/cy.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/da.js
+++ b/src/lang/da.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/es-es.js
+++ b/src/lang/es-es.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/fr-fr.js
+++ b/src/lang/fr-fr.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/ko.js
+++ b/src/lang/ko.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/zh-cn.js
+++ b/src/lang/zh-cn.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/src/lang/zh-tw.js
+++ b/src/lang/zh-tw.js
@@ -1,4 +1,3 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components.drawer.close": "Close this drawer",
 };

--- a/test/components/drawer/drawer.test.js
+++ b/test/components/drawer/drawer.test.js
@@ -1,0 +1,20 @@
+import '../../../src/components/drawer/drawer.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('Drawer', () => {
+
+	describe('accessibility', () => {
+		it('should pass all aXe tests', async() => {
+			const el = await fixture(html`<d2l-labs-drawer></d2l-labs-drawer>`);
+			await expect(el).to.be.accessible();
+		});
+	});
+
+	describe('constructor', () => {
+		it('should construct', () => {
+			runConstructor('d2l-labs-drawer');
+		});
+	});
+
+});

--- a/test/components/drawer/drawer.visual-diff.html
+++ b/test/components/drawer/drawer.visual-diff.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<script type="module">
+			import '@brightspace-ui/core/components/typography/typography.js';
+			import '../drawer.js';
+		</script>
+		<title>d2l-labs-drawer visual-diff tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+	</head>
+	<body class="d2l-typography">
+		<div>
+			<d2l-labs-drawer id="default"></d2l-labs-drawer>
+		</div>
+	</body>
+</html>

--- a/test/components/drawer/drawer.visual-diff.js
+++ b/test/components/drawer/drawer.visual-diff.js
@@ -1,0 +1,28 @@
+import puppeteer from 'puppeteer';
+import { VisualDiff } from '@brightspace-ui/visual-diff';
+
+describe('d2l-labs-drawer', () => {
+
+	const visualDiff = new VisualDiff('drawer', import.meta.url);
+
+	let browser, page;
+
+	before(async() => {
+		browser = await puppeteer.launch();
+		page = await visualDiff.createPage(browser);
+		await page.goto(`${visualDiff.getBaseUrl()}/test/drawer.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
+		await page.bringToFront();
+	});
+
+	beforeEach(async() => {
+		await visualDiff.resetFocus(page);
+	});
+
+	after(async() => await browser.close());
+
+	it('passes visual-diff comparison', async function() {
+		const rect = await visualDiff.getRect(page, '#default');
+		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
+	});
+
+});


### PR DESCRIPTION
Letting drawer finally see some daylight rather than sitting locally in on my dust shelf.
Drawer is a _modal that is anchored to the edge of the viewport or parent container_

The readme.md placed within the drawer directory explains more than I will in this PR description
- Essentially, there's still a lot to do on this component but I feel like it's a waste to just let it sit forgotten on my desktop.
- A couple of these features are more or less critical though, IMO so without them I didn't even consider this component ready for consumption on a labs level so I'm not exporting it via package.json at this moment in time

Took inspiration from the following sources for drawer:
[Shoelace](https://shoelace.style/components/drawer)
[Mantine](https://mantine.dev/core/drawer/)
[Material-UI](https://mui.com/material-ui/react-drawer/#main-content)

Also did some housekeeping in the repo:
- Updated .eslint.json for demo console logs & lang file quotes
- Added a new mixin for `localizeLabsElement` which is a copy paste of `localizeCoreElement` for labs repo

Should note that this component has a decent amount in common with `dialog.js` from core - so anyone familiar with that code would probably have the most input on this component?

Demo screenshot
<img width="451" alt="image" src="https://user-images.githubusercontent.com/13713459/201730272-547a3ca8-96bf-4b82-be59-e3211def0087.png">
