### PR TITLE
Always update prevDeps even if shouldCompute returns false

### DIFF
--- a/src/controllers/computed-values/computed-value.js
+++ b/src/controllers/computed-values/computed-value.js
@@ -68,9 +68,10 @@ export default class ComputedValue {
 
 	hostUpdate() {
 		const currDependencies = this._getDependencies();
+		const shouldCompute = this._shouldCompute(this._prevDependencies, currDependencies);
+		this._prevDependencies = currDependencies;
 
-		if (this._shouldCompute(this._prevDependencies, currDependencies)) {
-			this._prevDependencies = currDependencies;
+		if (shouldCompute) {
 			this._updateValue(currDependencies);
 		}
 	}


### PR DESCRIPTION
Found a small issue with custom implementations of `shouldCompute`.

After every run of `shouldCompute`, the `ComputeValue` class stores the `currDependencies` so they can be the `prevDependencies` the next time this runs. However, if `shouldCompute` returned `false`, the class was making the assumption that the dependencies hadn't changed, so there was no need to store the `currDependencies` for next time. This is true when using the default implementation of `shouldCompute`, but that's not always the case if you were to implement a custom `shouldCompute` function.

The logic here is now being updated so that `currDependencies` is always stored for the next run regardless of whatever `shouldCompute` returns so that checks for changes are accurate to every update.

Note that a quick search shows no one is currently implementing a custom `shouldCompute` function: https://search.d2l.dev/search?full=shouldCompute&defs=&refs=&path=&hist=&type=&xrd=&nn=8&si=full&searchall=true&si=full