### PR TITLE
Set up update-package-lock github action

### DIFF
--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -7,7 +7,7 @@ jobs:
   update:
     name: Update
     timeout-minutes: 10
-    runs-on: [self-hosted, Linux, AWS]
+    runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
         with:
@@ -16,10 +16,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - name: Add CodeArtifact npm registry
-        uses: Brightspace/codeartifact-actions/npm/add-registry@main
-        with:
-          auth-token: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
       - name: Update package-lock.json
         uses: BrightspaceUI/actions/update-package-lock@main
         with:

--- a/.github/workflows/update-package-lock.yml
+++ b/.github/workflows/update-package-lock.yml
@@ -1,0 +1,29 @@
+name: Update package-lock.json
+on:
+  schedule:
+    - cron: "30 12 * * 1-5" # Mon-Fri 8:30AM EDT. 7:30AM EST.
+  workflow_dispatch: # manual trigger
+jobs:
+  update:
+    name: Update
+    timeout-minutes: 10
+    runs-on: [self-hosted, Linux, AWS]
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          token: ${{ secrets.PR_GITHUB_TOKEN }}
+      - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Add CodeArtifact npm registry
+        uses: Brightspace/codeartifact-actions/npm/add-registry@main
+        with:
+          auth-token: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
+      - name: Update package-lock.json
+        uses: BrightspaceUI/actions/update-package-lock@main
+        with:
+          AUTO_MERGE_METHOD: squash
+          AUTO_MERGE_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
+          APPROVAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @BrightspaceUI/gaudi-dev
+package-lock.json


### PR DESCRIPTION
Adding github action to run update-package-lock based on the following guide: https://desire2learn.atlassian.net/wiki/spaces/DEVCENTRAL/pages/3643179788/How+to+track+and+manage+JavaScript+dependencies+with+package-lock.json#What-should-I-do%3F

This is currently set up to run Mon-Fri 7:30am EST. Let me know if you think this should be at a different time or less frequent.

Will do some testing once merged to make sure it works as expected.