### PR TITLE
feat: move opt-in flyout component into labs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,13 @@
 {
-  "extends": "brightspace/lit-config"
+  "extends": "brightspace/lit-config",
+  "overrides": [
+    {
+      "files": [
+        "src/lang/*.js"
+      ],
+      "rules": {
+        "quotes": 0
+      }
+    }
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,14 @@
       "rules": {
         "quotes": 0
       }
+    },
+    {
+      "files": [
+        "demo/**/**.html"
+      ],
+      "rules": {
+        "no-console": 0
+      }
     }
   ]
 }

--- a/demo/components/opt-in-flyout/index.html
+++ b/demo/components/opt-in-flyout/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../../src/components/opt-in-flyout/opt-in-flyout.js';
+			import '../../../src/components/opt-in-flyout/opt-out-flyout.js';
+			import '../../../src/components/opt-in-flyout/opt-out-reason.js';
+		</script>
+		<title>opt-in-flyout demo</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<style>
+			.flyout-wrapper {
+				height: 450px;
+				position: relative;
+				width: 100%;
+			}
+		</style>
+	</head>
+	<body>
+		<d2l-demo-page page-title="Opt-in Flyout">
+
+			<d2l-demo-snippet no-padding>
+				<div class="flyout-wrapper">
+					<d2l-opt-in-flyout
+						open
+						title="Flyout Demo Opt-in"
+						short-description="This is a <b>short</b> description" long-description="This is a <b>long</b> description"
+						tab-position="right"
+						tutorial-link="https://www.example.com#tutorial"
+						help-docs-link="https://www.example.com#documentation">
+					</d2l-opt-in-flyout>
+				</div>
+			</d2l-demo-snippet>
+
+			<d2l-demo-snippet no-padding>
+				<div class="flyout-wrapper">
+					<d2l-opt-out-flyout
+						open
+						title="Flyout Demo Opt-out"
+						short-description="This is a <b>short</b> description"
+						long-description="This is a <b>long</b> description"
+						tab-position="right"
+						tutorial-link="https://www.example.com#tutorial"
+						help-docs-link="https://www.example.com#documentation">
+					</d2l-opt-out-flyout>
+				</div>
+			</d2l-demo-snippet>
+
+			<d2l-demo-snippet no-padding>
+				<div class="flyout-wrapper">
+					<d2l-opt-out-flyout
+						open
+						title="Flyout Demo Opt-out"
+						short-description="This is a <b>short</b> description"
+						long-description="This is a <b>long</b> description"
+						tab-position="right"
+						tutorial-link="https://www.example.com#tutorial"
+						help-docs-link="https://www.example.com#documentation">
+						<d2l-opt-out-reason key="test-1" text="Test Option 1"></d2l-opt-out-reason>
+						<d2l-opt-out-reason key="test-2" text="Test Option 2"></d2l-opt-out-reason>
+					</d2l-opt-out-flyout>
+				</div>
+			</d2l-demo-snippet>
+
+			<d2l-demo-snippet no-padding>
+				<div class="flyout-wrapper">
+					<d2l-opt-out-flyout
+						hide-reason
+						hide-feedback
+						open
+						title="Flyout Demo Opt-out - dialog disabled"
+						short-description="This is a <b>short</b> description"
+						long-description="This is a <b>long</b> description"
+						tab-position="right"
+						tutorial-link="https://www.example.com#tutorial"
+						help-docs-link="https://www.example.com#documentation">
+					</d2l-opt-out-flyout>
+				</div>
+			</d2l-demo-snippet>
+
+			<script type="module">
+				[...document.querySelectorAll('d2l-opt-in-flyout, d2l-opt-out-flyout')].forEach(elem => {
+					['flyout-opened', 'flyout-closed', 'opt-in', 'opt-out'].forEach(eventName => {
+						// eslint-disable-next-line no-console
+						elem.addEventListener(eventName, (event) => console.log(eventName, JSON.stringify(event.detail)));
+					});
+				});
+			</script>
+		</d2l-demo-page>
+	</body>
+</html>

--- a/demo/components/opt-in-flyout/index.html
+++ b/demo/components/opt-in-flyout/index.html
@@ -24,20 +24,20 @@
 
 			<d2l-demo-snippet no-padding>
 				<div class="flyout-wrapper">
-					<d2l-opt-in-flyout
+					<d2l-labs-opt-in-flyout
 						open
 						title="Flyout Demo Opt-in"
 						short-description="This is a <b>short</b> description" long-description="This is a <b>long</b> description"
 						tab-position="right"
 						tutorial-link="https://www.example.com#tutorial"
 						help-docs-link="https://www.example.com#documentation">
-					</d2l-opt-in-flyout>
+					</d2l-labs-opt-in-flyout>
 				</div>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet no-padding>
 				<div class="flyout-wrapper">
-					<d2l-opt-out-flyout
+					<d2l-labs-opt-out-flyout
 						open
 						title="Flyout Demo Opt-out"
 						short-description="This is a <b>short</b> description"
@@ -45,13 +45,13 @@
 						tab-position="right"
 						tutorial-link="https://www.example.com#tutorial"
 						help-docs-link="https://www.example.com#documentation">
-					</d2l-opt-out-flyout>
+					</d2l-labs-opt-out-flyout>
 				</div>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet no-padding>
 				<div class="flyout-wrapper">
-					<d2l-opt-out-flyout
+					<d2l-labs-opt-out-flyout
 						open
 						title="Flyout Demo Opt-out"
 						short-description="This is a <b>short</b> description"
@@ -59,15 +59,15 @@
 						tab-position="right"
 						tutorial-link="https://www.example.com#tutorial"
 						help-docs-link="https://www.example.com#documentation">
-						<d2l-opt-out-reason key="test-1" text="Test Option 1"></d2l-opt-out-reason>
-						<d2l-opt-out-reason key="test-2" text="Test Option 2"></d2l-opt-out-reason>
-					</d2l-opt-out-flyout>
+						<d2l-labs-opt-out-reason key="test-1" text="Test Option 1"></d2l-labs-opt-out-reason>
+						<d2l-labs-opt-out-reason key="test-2" text="Test Option 2"></d2l-labs-opt-out-reason>
+					</d2l-labs-opt-out-flyout>
 				</div>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet no-padding>
 				<div class="flyout-wrapper">
-					<d2l-opt-out-flyout
+					<d2l-labs-opt-out-flyout
 						hide-reason
 						hide-feedback
 						open
@@ -77,12 +77,12 @@
 						tab-position="right"
 						tutorial-link="https://www.example.com#tutorial"
 						help-docs-link="https://www.example.com#documentation">
-					</d2l-opt-out-flyout>
+					</d2l-labs-opt-out-flyout>
 				</div>
 			</d2l-demo-snippet>
 
 			<script type="module">
-				[...document.querySelectorAll('d2l-opt-in-flyout, d2l-opt-out-flyout')].forEach(elem => {
+				[...document.querySelectorAll('d2l-labs-opt-in-flyout, d2l-labs-opt-out-flyout')].forEach(elem => {
 					['flyout-opened', 'flyout-closed', 'opt-in', 'opt-out'].forEach(eventName => {
 						// eslint-disable-next-line no-console
 						elem.addEventListener(eventName, (event) => console.log(eventName, JSON.stringify(event.detail)));

--- a/demo/components/opt-in-flyout/index.html
+++ b/demo/components/opt-in-flyout/index.html
@@ -8,7 +8,6 @@
 			import '../../../src/components/opt-in-flyout/opt-out-flyout.js';
 			import '../../../src/components/opt-in-flyout/opt-out-reason.js';
 		</script>
-		<title>opt-in-flyout demo</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<style>
@@ -19,7 +18,7 @@
 			}
 		</style>
 	</head>
-	<body>
+	<body unresolved>
 		<d2l-demo-page page-title="Opt-in Flyout">
 
 			<d2l-demo-snippet no-padding>

--- a/demo/components/opt-in-flyout/index.html
+++ b/demo/components/opt-in-flyout/index.html
@@ -22,62 +22,70 @@
 		<d2l-demo-page page-title="Opt-in Flyout">
 
 			<d2l-demo-snippet no-padding>
-				<div class="flyout-wrapper">
-					<d2l-labs-opt-in-flyout
-						open
-						title="Flyout Demo Opt-in"
-						short-description="This is a <b>short</b> description" long-description="This is a <b>long</b> description"
-						tab-position="right"
-						tutorial-link="https://www.example.com#tutorial"
-						help-docs-link="https://www.example.com#documentation">
-					</d2l-labs-opt-in-flyout>
-				</div>
+				<template>
+					<div class="flyout-wrapper">
+						<d2l-labs-opt-in-flyout
+							open
+							title="Flyout Demo Opt-in"
+							short-description="This is a <b>short</b> description" long-description="This is a <b>long</b> description"
+							tab-position="right"
+							tutorial-link="https://www.example.com#tutorial"
+							help-docs-link="https://www.example.com#documentation">
+						</d2l-labs-opt-in-flyout>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet no-padding>
-				<div class="flyout-wrapper">
-					<d2l-labs-opt-out-flyout
-						open
-						title="Flyout Demo Opt-out"
-						short-description="This is a <b>short</b> description"
-						long-description="This is a <b>long</b> description"
-						tab-position="right"
-						tutorial-link="https://www.example.com#tutorial"
-						help-docs-link="https://www.example.com#documentation">
-					</d2l-labs-opt-out-flyout>
-				</div>
+				<template>
+					<div class="flyout-wrapper">
+						<d2l-labs-opt-out-flyout
+							open
+							title="Flyout Demo Opt-out"
+							short-description="This is a <b>short</b> description"
+							long-description="This is a <b>long</b> description"
+							tab-position="right"
+							tutorial-link="https://www.example.com#tutorial"
+							help-docs-link="https://www.example.com#documentation">
+						</d2l-labs-opt-out-flyout>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet no-padding>
-				<div class="flyout-wrapper">
-					<d2l-labs-opt-out-flyout
-						open
-						title="Flyout Demo Opt-out"
-						short-description="This is a <b>short</b> description"
-						long-description="This is a <b>long</b> description"
-						tab-position="right"
-						tutorial-link="https://www.example.com#tutorial"
-						help-docs-link="https://www.example.com#documentation">
-						<d2l-labs-opt-out-reason key="test-1" text="Test Option 1"></d2l-labs-opt-out-reason>
-						<d2l-labs-opt-out-reason key="test-2" text="Test Option 2"></d2l-labs-opt-out-reason>
-					</d2l-labs-opt-out-flyout>
-				</div>
+				<template>
+					<div class="flyout-wrapper">
+						<d2l-labs-opt-out-flyout
+							open
+							title="Flyout Demo Opt-out"
+							short-description="This is a <b>short</b> description"
+							long-description="This is a <b>long</b> description"
+							tab-position="right"
+							tutorial-link="https://www.example.com#tutorial"
+							help-docs-link="https://www.example.com#documentation">
+							<d2l-labs-opt-out-reason key="test-1" text="Test Option 1"></d2l-labs-opt-out-reason>
+							<d2l-labs-opt-out-reason key="test-2" text="Test Option 2"></d2l-labs-opt-out-reason>
+						</d2l-labs-opt-out-flyout>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<d2l-demo-snippet no-padding>
-				<div class="flyout-wrapper">
-					<d2l-labs-opt-out-flyout
-						hide-reason
-						hide-feedback
-						open
-						title="Flyout Demo Opt-out - dialog disabled"
-						short-description="This is a <b>short</b> description"
-						long-description="This is a <b>long</b> description"
-						tab-position="right"
-						tutorial-link="https://www.example.com#tutorial"
-						help-docs-link="https://www.example.com#documentation">
-					</d2l-labs-opt-out-flyout>
-				</div>
+				<template>
+					<div class="flyout-wrapper">
+						<d2l-labs-opt-out-flyout
+							hide-reason
+							hide-feedback
+							open
+							title="Flyout Demo Opt-out - dialog disabled"
+							short-description="This is a <b>short</b> description"
+							long-description="This is a <b>long</b> description"
+							tab-position="right"
+							tutorial-link="https://www.example.com#tutorial"
+							help-docs-link="https://www.example.com#documentation">
+						</d2l-labs-opt-out-flyout>
+					</div>
+				</template>
 			</d2l-demo-snippet>
 
 			<script type="module">

--- a/demo/components/opt-in-flyout/index.html
+++ b/demo/components/opt-in-flyout/index.html
@@ -91,7 +91,6 @@
 			<script type="module">
 				[...document.querySelectorAll('d2l-labs-opt-in-flyout, d2l-labs-opt-out-flyout')].forEach(elem => {
 					['flyout-opened', 'flyout-closed', 'opt-in', 'opt-out'].forEach(eventName => {
-						// eslint-disable-next-line no-console
 						elem.addEventListener(eventName, (event) => console.log(eventName, JSON.stringify(event.detail)));
 					});
 				});

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 			import '@brightspace-ui/core/components/colors/colors.js';
 			import '@brightspace-ui/core/components/typography/typography.js';
 		</script>
-		<title>core-ui</title>
+		<title>labs</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta charset="UTF-8">
 		<style>

--- a/index.html
+++ b/index.html
@@ -1,28 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-	<script type="module">
-        import '@brightspace-ui/core/components/colors/colors.js';
-        import '@brightspace-ui/core/components/typography/typography.js';
-	</script>
-	<title>core-ui</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta charset="UTF-8">
-	<style>
-		body {
-			padding: 0 30px;
-		}
-	</style>
-</head>
-<body class="d2l-typography">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script type="module">
+			import '@brightspace-ui/core/components/colors/colors.js';
+			import '@brightspace-ui/core/components/typography/typography.js';
+		</script>
+		<title>core-ui</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta charset="UTF-8">
+		<style>
+			body {
+				padding: 0 30px;
+			}
+		</style>
+	</head>
+	<body class="d2l-typography">
 
-	<h1 class="d2l-heading-2">Demos</h1>
+		<h1 class="d2l-heading-2">Demos</h1>
 
-	<h2 class="d2l-heading-3">Controllers</h2>
-	<ul>
-		<li><a href="demo/controllers/computed-values/index.html">ComputedValues</a></li>
-	</ul>
+		<h2 class="d2l-heading-2">Components</h2>
+		<ul>
+			<li><a href="demo/components/opt-in-flyout/index.html">Opt-In Flyout</a></li>
+		</ul>
 
-</body>
+		<h2 class="d2l-heading-3">Controllers</h2>
+		<ul>
+			<li><a href="demo/controllers/computed-values/index.html">ComputedValues</a></li>
+		</ul>
+
+	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "repository": "https://github.com/BrightspaceUI/labs.git",
   "exports": {
+    "./components/opt-in-flyout.js": "./src/components/opt-in-flyout/opt-in-flyout.js",
+    "./components/opt-out-flyout.js": "./src/components/opt-in-flyout/opt-out-flyout.js",
+    "./components/opt-out-reason.js": "./src/components/opt-in-flyout/opt-out-reason.js",
     "./controllers/computed-value.js": "./src/controllers/computed-values/computed-value.js",
     "./controllers/computed-values.js": "./src/controllers/computed-values/computed-values.js"
   },

--- a/src/components/localize-labs-element.js
+++ b/src/components/localize-labs-element.js
@@ -1,0 +1,11 @@
+import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
+
+export const LocalizeLabsElement = (superclass) => class extends LocalizeDynamicMixin(superclass) {
+
+	static get localizeConfig() {
+		return {
+			importFunc: async lang => (await import(`../lang/${lang}.js`)).default
+		};
+	}
+
+};

--- a/src/components/opt-in-flyout/README.md
+++ b/src/components/opt-in-flyout/README.md
@@ -1,0 +1,59 @@
+# Opt-in/Opt-out Flyouts
+
+The `<d2l-labs-opt-in-flyout>` and `<d2l-labs-opt-out-flyout>` can be used in applications to enable users to opt-in or out of new experiences.
+
+<!-- docs: start hidden content -->
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `open` | Boolean, default: `false` | Indicates the opened or closed state of the flyout |
+| `title` | String, required | Title to display at the top of the flyout |
+| `short-description` | String |Descriptive text shown beneath the `title` |
+| `long-description` | String | Additional text shown beneath `short-description` |
+| `tab-position` | String, default: `'right'` | Position to display the expand/collapse tab. Can either be an integer percentage (including the `%` character) or the string `left`, `right`, or `center`/`centre`. |
+| `tutorial-link` | String | A URL for a tutorial of the new experience or feature |
+| `help-docs-link` | String | A URL for help documentation on the new experience or feature |
+
+Additional properties for `<d2l-labs-opt-out-flyout>`:
+
+| Property | Type | Description |
+|---|---|---|
+| `hide-reason` | Boolean, default: `false` | Hides the reason field from the opt-out dialog |
+| `hide-feedback` | Boolean, default: `false` | Hides the feedback textarea field from the opt-out dialog |
+
+If both `hide-reason` _and_ `hide-feedback` are specified, the opt-out dialog will not display.
+
+### Events
+* `flyout-opened`: flyout was expanded
+* `flyout-closed`: flyout was collapsed
+* `opt-in`: *Turn it on* / *Leave it on* button was clicked
+* `opt-out`: *Leave it off* / *Turn it off* button was clicked
+<!-- docs: end hidden content -->
+
+## Opt-out Reasons
+
+By default, `<d2l-labs-opt-out-flyout>` will make the following opt-out reasons available to the user, in addition to "other":
+
+| key | English text |
+| ----------------------- | ----------------------------------------------- |
+| `NotReadyForSomethingNew` | It's not a good time for me to try this version |
+| `MissingFeature` | It's missing a feature that I use |
+| `JustCheckingSomething` | Just switching back to check something |
+| `PreferOldExperience` | I think the old version is a better experience |
+
+To provide custom reasons, place `<d2l-labs-opt-out-reason>` elements as children of `<d2l-labs-opt-out-flyout>`.
+
+<!-- docs: start hidden content -->
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `key` | String, required | Uniquely identifies the opt-out reason |
+| `text` | String, required | Text that will be displayed to the user |
+<!-- docs: end hidden content -->
+
+When the `opt-out` event is fired from `<d2l-labs-opt-out-flyout>`, its `detail` will contain:
+
+* `reason`: unique identifier for the opt-out reason
+* `feedback`: optional feedback provided by the user

--- a/src/components/opt-in-flyout/flyout-impl.js
+++ b/src/components/opt-in-flyout/flyout-impl.js
@@ -1,0 +1,501 @@
+import '@brightspace-ui/core/components/button/button.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/html-block/html-block.js';
+import './opt-out-dialog.js';
+import { bodyStandardStyles, heading1Styles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html, LitElement, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { composeMixins } from '@brightspace-ui/core/helpers/composeMixins.js';
+import { LocalizeLabsElement } from '../localize-labs-element.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+
+const VISIBLE_STATES = Object.freeze({
+	opened: 'OPENED',
+	opening: 'OPENING',
+	closed: 'CLOSED',
+	closing: 'CLOSING'
+});
+
+class FlyoutImplementation extends composeMixins(
+	LitElement,
+	LocalizeLabsElement,
+	RtlMixin
+) {
+
+	static get properties() {
+		return {
+			optOut: { type: Boolean, attribute: 'opt-out' },
+			open: { type: Boolean, reflect: true },
+			title: { type: String },
+			shortDescription: { type: String, attribute: 'short-description' },
+			longDescription: { type: String, attribute: 'long-description' },
+			tabPosition: { type: String, attribute: 'tab-position' },
+			noTransform: { type: Boolean, attribute: 'no-transform' },
+			tutorialLink: { type: String, attribute: 'tutorial-link' },
+			helpDocsLink: { type: String, attribute: 'help-docs-link' },
+			hideReason: { type: Boolean, attribute: 'hide-reason' },
+			hideFeedback: { type: Boolean, attribute: 'hide-feedback' },
+			_optOutDialogOpen: { state: true },
+			_primaryButtonText: { state: true },
+			_secondaryButtonText: { state: true },
+			_visibleState: { state: true },
+			_ariaLabel: { state: true },
+			_tabIndex: { state: true }
+		};
+	}
+
+	static get styles() {
+		return [
+			bodyStandardStyles,
+			heading1Styles,
+			css`
+				:host {
+					height: 100%;
+					overflow: hidden;
+					pointer-events: none;
+					position: absolute;
+					width: 100%;
+				}
+
+				#flyout {
+					background-color: white;
+					border-bottom: 1px solid var(--d2l-color-mica);
+					box-sizing: border-box;
+					overflow: visible;
+					padding-bottom: 2rem;
+					pointer-events: auto;
+					position: var(--d2l-flyout-custom-element-position, absolute);
+					top: var(--d2l-flyout-custom-element-top, 0);
+					width: 100%;
+					z-index: var(--d2l-flyout-custom-element-z-index, 900);
+				}
+
+				#flyout.flyout-opened {
+					transition: transform 0.2s ease-out;
+				}
+
+				#flyout.flyout-closed {
+					transition: transform 0.2s ease-in;
+				}
+
+				.flyout-opened {
+					transform: translateY(0);
+				}
+				.flyout-closed {
+					transform: translateY(-100%);
+				}
+
+				.flyout-content {
+					text-align: center;
+				}
+
+				.flyout-content h1 {
+					margin-bottom: 1.2rem;
+				}
+
+				.flyout-text {
+					align-items: center;
+					display: flex;
+					flex-direction: column;
+					margin-bottom: 1.5rem;
+				}
+
+				#short-description {
+					margin-bottom: 0.5rem;
+				}
+
+				#long-description {
+					max-width: 800px;
+				}
+
+				.flyout-tutorial {
+					margin: auto;
+					margin-top: 0.5em;
+				}
+
+				.flyout-tutorial a {
+					color: var(--d2l-color-celestine);
+					text-decoration: none;
+				}
+
+				.flyout-tutorial a:hover, .flyout-tutorial a:focus {
+					text-decoration: underline;
+				}
+
+				.flyout-buttons {
+					margin-left: auto;
+					margin-right: auto;
+				}
+
+				.flyout-buttons d2l-button {
+					margin-left: 0.5rem;
+					margin-right: 0.5rem;
+				}
+
+				.flyout-tab-container {
+					height: 1.2rem;
+					left: 50%;
+					max-width: 1230px;
+					overflow: hidden;
+					pointer-events: none;
+					position: absolute;
+					top: 100%;
+					transform: translateX(-50%);
+					width: 100%;
+				}
+
+				.flyout-tab {
+					background-color: white;
+					border: 1px solid var(--d2l-color-mica);
+					border-radius: 0 0 8px 8px;
+					border-top: none;
+					box-sizing: border-box;
+					cursor: pointer;
+					height: 1rem;
+					min-height: 0;
+					padding: 1px;
+					pointer-events: auto;
+					position: absolute;
+					text-align: center;
+					top: 0;
+					width: 5rem;
+				}
+
+				.flyout-tab:hover, .flyout-tab:focus {
+					background-color: var(--d2l-color-gypsum);
+				}
+
+				.flyout-tab:focus {
+					border-color: rgba(0, 111, 191, 0.4);
+					border-style: solid;
+					border-width: 0 1px 1px 1px;
+					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+				}
+
+				.flyout-tab:active, .flyout-tab:focus {
+					outline: 0;
+				}
+
+				.flyout-tab > d2l-icon {
+					margin: auto;
+					vertical-align: top !important;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this.tabPosition = 'right';
+		this._visibleState = VISIBLE_STATES.closed;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this._visibleState = this.open ? VISIBLE_STATES.opened : VISIBLE_STATES.closed;
+	}
+
+	render() {
+		return html`
+			${this._renderOptInDialog()}
+			<div id="flyout" class="${classMap(this._getFlyoutClasses())}" @transitionend="${this._onTransitionComplete}">
+				<span tabindex="${this._getTabIndex()}" @focus="${this._shiftToLast}"></span>
+				${this._renderFlyoutContent()}
+				<div class="flyout-tab-container">
+					<button id="flyout-tab" class="flyout-tab" style="${this._getTabStyle()}" tabindex="0" aria-label="${this._getAriaLabelForTab()}" @click="${this._clickTab}">
+						<d2l-icon icon="${this._getTabIcon()}"></d2l-icon>
+					</button>
+				</div>
+				<span tabindex="${this._getTabIndex()}" @focus="${this._shiftToFirst}"></span>
+			</div>
+		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('open')) {
+			this._openChanged();
+		}
+	}
+
+	focus() {
+		this._shiftToFirst();
+	}
+
+	_cancelOptOut(event) {
+		this._optOutDialogOpen = false;
+		this.shadowRoot.querySelector('#opt-out-button').focus();
+		event.stopPropagation();
+	}
+
+	_checkNumberOfLinks(expectedNumber) {
+		let result;
+		if (this.tutorialLink && this.helpDocsLink) {
+			result = 2;
+		} else if (this.tutorialLink || this.helpDocsLink) {
+			result = 1;
+		} else {
+			result = 0;
+		}
+		return result === expectedNumber;
+	}
+
+	_clickOptIn() {
+		this._fireEvent('opt-in');
+		this.open = false;
+	}
+
+	_clickOptOut() {
+		if (this.optOut && (!this.hideReason || !this.hideFeedback)) {
+			this._optOutDialogOpen = true;
+		} else {
+			this._fireEvent('opt-out');
+			this.open = false;
+		}
+	}
+
+	_clickTab() {
+		if (this._visibleState === VISIBLE_STATES.opened || this._visibleState === VISIBLE_STATES.closed) {
+			this.open = !this.open;
+		}
+	}
+
+	_confirmOptOut(event) {
+		this._optOutDialogOpen = false;
+		this._fireEvent('opt-out', event.detail);
+		this.open = false;
+		event.stopPropagation();
+	}
+
+	_fireEvent(name, details) {
+		this.dispatchEvent(
+			new CustomEvent(
+				name, {
+					bubbles: true,
+					composed: true,
+					detail: details
+				}
+			)
+		);
+	}
+
+	_getAriaLabelForTab() {
+		if (this.open) {
+			return this.localize('components:optInFlyout:close');
+		}
+		return this.localize(this.optOut ? 'components:optInFlyout:openOptOut' : 'components:optInFlyout:openOptIn');
+	}
+
+	_getDescription() {
+		return this.shortDescription ? 'short-description' : (this.longDescription ? 'long-description' : '');
+	}
+
+	_getFlyoutClasses() {
+		const openState = this._visibleState === VISIBLE_STATES.opening || this._visibleState === VISIBLE_STATES.opened;
+		return {
+			'flyout-opened': openState,
+			'flyout-closed': !openState,
+			'd2l-body-standard': true
+		};
+	}
+
+	_getPrimaryButtonText() {
+		return this.localize(this.optOut ? 'components:optInFlyout:leaveOn' : 'components:optInFlyout:turnOn');
+	}
+
+	_getSecondaryButtonText() {
+		return this.localize(this.optOut ? 'components:optInFlyout:turnOff' : 'components:optInFlyout:leaveOff');
+	}
+
+	_getTabIcon() {
+		if (this._visibleState === VISIBLE_STATES.closed || this._visibleState === VISIBLE_STATES.closing) {
+			return 'tier1:chevron-down';
+		} else {
+			return 'tier1:chevron-up';
+		}
+	}
+
+	_getTabIndex() {
+		return this.open ? 0 : -1;
+	}
+
+	_getTabStyle() {
+		let rtl = this.dir === 'rtl';
+		let position = '';
+		if (this.tabPosition === 'left') {
+			position = 'calc(2.5rem + 15px)';
+		} else if (this.tabPosition === 'right' || this.tabPosition === 'default' || !this.tabPosition) {
+			position = 'calc(2.5rem + 15px)';
+			rtl = !rtl;
+		} else if (this.tabPosition === 'center' || this.tabPosition === 'centre') {
+			position = '50%';
+		} else if (!/^\d+(?:\.\d+)?%$/.test(this.tabPosition)) {
+			/* eslint-disable no-console */
+			console.warn('Invalid position supplied to opt-in flyout');
+			position = 'calc(2.5rem + 15px)';
+			rtl = !rtl;
+		}
+
+		const side = rtl ? 'right' : 'left';
+		const shift = rtl ? '50%' : '-50%';
+
+		const tabStyle = `${side}: ${position};`;
+
+		if (this.noTransform) {
+			return tabStyle;
+		}
+
+		return `${tabStyle} transform: translateX(${shift});`;
+	}
+
+	_getTutorialLink(i) {
+		if (this.tutorialLink && this.helpDocsLink) {
+			const translation = this.localize('components:optInFlyout:tutorialAndHelpMessage');
+			const videoFirst = translation.indexOf('*') < translation.indexOf('~');
+
+			const links = videoFirst ? [this.tutorialLink, this.helpDocsLink] : [this.helpDocsLink, this.tutorialLink];
+			return links[i];
+		}
+		return this.tutorialLink || this.helpDocsLink || null;
+	}
+
+	_getTutorialTextPart(textPart) {
+		if (this.tutorialLink && this.helpDocsLink) {
+			const tutorialHelpMessage = this.localize('components:optInFlyout:tutorialAndHelpMessage');
+			return tutorialHelpMessage.split(/\*|~/)[textPart] || '';
+		} else if (this.tutorialLink || this.helpDocsLink) {
+			const individualMessage = this.localize(this.tutorialLink ? 'components:optInFlyout:tutorialMessage' : 'components:optInFlyout:helpMessage');
+			return individualMessage.split('*')[textPart] || '';
+		} else {
+			return null;
+		}
+	}
+
+	_onTransitionComplete(event) {
+		if (event.target.id !== 'flyout' || event.propertyName !== 'transform') {
+			return null;
+		}
+
+		if (this._visibleState === VISIBLE_STATES.opening) {
+			this._visibleState = VISIBLE_STATES.opened;
+			this.shadowRoot.querySelector('#primary-button').focus();
+		} else if (this._visibleState === VISIBLE_STATES.closing) {
+			this._visibleState = VISIBLE_STATES.closed;
+			this.shadowRoot.querySelector('#flyout-tab').focus();
+		}
+	}
+
+	_openChanged() {
+		if (this.open && this._visibleState === VISIBLE_STATES.closed || this._visibleState === VISIBLE_STATES.closing) {
+			this._visibleState = VISIBLE_STATES.opening;
+		} else if (!this.open && this._visibleState === VISIBLE_STATES.opened || this._visibleState === VISIBLE_STATES.opening) {
+			this._visibleState = VISIBLE_STATES.closing;
+		}
+		this._fireEvent(this.open ? 'flyout-opened' : 'flyout-closed');
+	}
+
+	_renderFlyoutContent() {
+		if (this._visibleState === VISIBLE_STATES.closed) {
+			return nothing;
+		}
+		return html`
+			<div id="flyout-content" role="dialog" aria-labelledby="title" aria-describedby="${this._getDescription()}" class="flyout-content">
+				<div class="flyout-text">
+					<h1 class="d2l-heading-1" id="title">${this.title}</h1>
+					${this._renderShortDescription()}
+					${this._renderLongDescription()}
+					${this._renderLinksText()}
+				</div>
+				<div class="flyout-buttons">
+					<d2l-button id="primary-button" primary="" @click="${this._clickOptIn}">${this._getPrimaryButtonText()}</d2l-button>
+					<d2l-button id="opt-out-button" @click="${this._clickOptOut}">${this._getSecondaryButtonText()}</d2l-button>
+				</div>
+			</div>
+		`;
+	}
+
+	_renderLinksText() {
+		if (this._checkNumberOfLinks(1)) {
+			return html`
+				<div class="flyout-tutorial">
+					<span>${this._getTutorialTextPart(0)}</span>
+					<a id="tutorial-link-1" href="${this._getTutorialLink(0)}" target="_blank" rel="noopener">
+						${this._getTutorialTextPart(1)}
+					</a>
+					<span>${this._getTutorialTextPart(2)}</span>
+				</div>
+			`;
+		} else if (this._checkNumberOfLinks(2)) {
+			return html`
+				<div class="flyout-tutorial">
+					<span>${this._getTutorialTextPart(0)}</span>
+					<a id="tutorial-link-2" href="${this._getTutorialLink(0)}" target="_blank" rel="noopener">
+						${this._getTutorialTextPart(1)}
+					</a>
+					<span>${this._getTutorialTextPart(2)}</span>
+					<a href="${this._getTutorialLink(1)}" target="_blank" rel="noopener">
+						${this._getTutorialTextPart(3)}
+					</a>
+					<span>${this._getTutorialTextPart(4)}</span>
+				</div>
+			`;
+		}
+	}
+
+	_renderLongDescription() {
+		if (!this.longDescription) {
+			return nothing;
+		}
+		return html`
+			<div id="long-description">
+				<d2l-html-block html="${this.longDescription}"></d2l-html-block>
+			</div>
+		`;
+	}
+
+	_renderOptInDialog() {
+		if (!this._optOutDialogOpen) {
+			return nothing;
+		}
+		return html`
+			<d2l-opt-out-dialog
+				@cancel="${this._cancelOptOut}"
+				@confirm="${this._confirmOptOut}"
+				?hide-reason="${this.hideReason}"
+				?hide-feedback="${this.hideFeedback}">
+				<slot></slot>
+			</d2l-opt-out-dialog>
+		`;
+	}
+
+	_renderShortDescription() {
+		if (!this.shortDescription) {
+			return nothing;
+		}
+		return html`
+			<div id="short-description">
+				<d2l-html-block html="${this.shortDescription}"></d2l-html-block>
+			</div>
+		`;
+	}
+
+	_shiftToFirst() {
+		if (this.tutorialLink && this.helpDocsLink) {
+			this.shadowRoot.querySelector('#tutorial-link-2').focus();
+		} else if (this.tutorialLink || this.helpDocsLink) {
+			this.shadowRoot.querySelector('#tutorial-link-1').focus();
+		} else {
+			this.shadowRoot.querySelector('#primary-button').focus();
+		}
+	}
+
+	_shiftToLast() {
+		if (this.open) {
+			this.shadowRoot.querySelector('#flyout-tab').focus();
+		}
+	}
+
+}
+
+customElements.define('flyout-impl', FlyoutImplementation);

--- a/src/components/opt-in-flyout/flyout-impl.js
+++ b/src/components/opt-in-flyout/flyout-impl.js
@@ -459,13 +459,13 @@ class FlyoutImplementation extends composeMixins(
 			return nothing;
 		}
 		return html`
-			<d2l-opt-out-dialog
+			<d2l-labs-opt-out-dialog
 				@cancel="${this._cancelOptOut}"
 				@confirm="${this._confirmOptOut}"
 				?hide-reason="${this.hideReason}"
 				?hide-feedback="${this.hideFeedback}">
 				<slot></slot>
-			</d2l-opt-out-dialog>
+			</d2l-labs-opt-out-dialog>
 		`;
 	}
 
@@ -498,4 +498,4 @@ class FlyoutImplementation extends composeMixins(
 
 }
 
-customElements.define('flyout-impl', FlyoutImplementation);
+customElements.define('d2l-labs-opt-in-flyout-impl', FlyoutImplementation);

--- a/src/components/opt-in-flyout/opt-in-flyout.js
+++ b/src/components/opt-in-flyout/opt-in-flyout.js
@@ -1,0 +1,59 @@
+import '@brightspace-ui/core/components/typography/typography.js';
+import './flyout-impl.js';
+import { css, html, LitElement } from 'lit';
+
+class OptInFlyout extends LitElement {
+
+	static get properties() {
+		return {
+			open: { type: Boolean, reflect: true },
+			title: { type: String },
+			shortDescription: { type: String, attribute: 'short-description' },
+			longDescription: { type: String, attribute: 'long-description' },
+			tabPosition: { type: String, attribute: 'tab-position' },
+			tutorialLink: { type: String, attribute: 'tutorial-link' },
+			helpDocsLink: { type: String, attribute: 'help-docs-link' }
+		};
+	}
+
+	static get styles() {
+		return css`
+			flyout-impl {
+				font-size: 20px;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this.open = false;
+	}
+
+	render() {
+		return html`
+			<flyout-impl
+				class="d2l-typography"
+				title="${this.title}"
+				short-description="${this.shortDescription}"
+				long-description="${this.longDescription}"
+				tab-position="${this.tabPosition}"
+				tutorial-link="${this.tutorialLink}"
+				help-docs-link="${this.helpDocsLink}"
+				?open="${this.open}"
+				@flyout-opened="${this._handleOpened}"
+				@flyout-closed="${this._handleClosed}">
+			</flyout-impl>
+		`;
+	}
+
+	_handleClosed() {
+		this.open = false;
+	}
+
+	_handleOpened() {
+		this.open = true;
+	}
+
+}
+
+customElements.define('d2l-opt-in-flyout', OptInFlyout);

--- a/src/components/opt-in-flyout/opt-in-flyout.js
+++ b/src/components/opt-in-flyout/opt-in-flyout.js
@@ -18,7 +18,7 @@ class OptInFlyout extends LitElement {
 
 	static get styles() {
 		return css`
-			flyout-impl {
+			d2l-labs-opt-in-flyout-impl {
 				font-size: 20px;
 			}
 		`;
@@ -31,7 +31,7 @@ class OptInFlyout extends LitElement {
 
 	render() {
 		return html`
-			<flyout-impl
+			<d2l-labs-opt-in-flyout-impl
 				class="d2l-typography"
 				title="${this.title}"
 				short-description="${this.shortDescription}"
@@ -42,7 +42,7 @@ class OptInFlyout extends LitElement {
 				?open="${this.open}"
 				@flyout-opened="${this._handleOpened}"
 				@flyout-closed="${this._handleClosed}">
-			</flyout-impl>
+			</d2l-labs-opt-in-flyout-impl>
 		`;
 	}
 
@@ -56,4 +56,4 @@ class OptInFlyout extends LitElement {
 
 }
 
-customElements.define('d2l-opt-in-flyout', OptInFlyout);
+customElements.define('d2l-labs-opt-in-flyout', OptInFlyout);

--- a/src/components/opt-in-flyout/opt-out-dialog.js
+++ b/src/components/opt-in-flyout/opt-out-dialog.js
@@ -1,0 +1,204 @@
+import '@brightspace-ui/core/components/button/button.js';
+import '@brightspace-ui/core/components/button/button-icon.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/inputs/input-textarea.js';
+import './opt-out-reason-selector.js';
+import { css, html, LitElement } from 'lit';
+import { composeMixins } from '@brightspace-ui/core/helpers/composeMixins.js';
+import { LocalizeLabsElement } from '../localize-labs-element.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+
+const defaultEventProperties = {
+	bubbles: true,
+	composed: true
+};
+
+class OptOutDialog extends composeMixins(
+	LitElement,
+	LocalizeLabsElement,
+	RtlMixin
+) {
+
+	static get properties() {
+		return {
+			hideReason: { type: Boolean, attribute: 'hide-reason' },
+			hideFeedback: { type: Boolean, attribute: 'hide-feedback' }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				height: 100%;
+				overflow: hidden;
+				pointer-events: auto;
+				position: absolute;
+				width: 100%;
+				z-index: 950;
+			}
+
+			.opt-out-modal-fade {
+				background-color: #ffffff;
+				height: 100%;
+				opacity: 0.7;
+				position: absolute;
+				width: 100%;
+				z-index: 1;
+			}
+
+			.dialog {
+				background-color: #ffffff;
+				border: 1px solid var(--d2l-color-mica);
+				border-radius: 0.3rem;
+				box-shadow: 0 2px 12px rgba(86, 90, 92, 0.25);
+				box-sizing: border-box;
+				left: 50%;
+				max-width: 680px;
+				padding: 1rem;
+				position: absolute;
+				top: 7.5%;
+				transform: translateX(-50%);
+				width: 90%;
+				z-index: 2;
+			}
+
+			label {
+				display: block;
+				margin-bottom: 0.5rem;
+			}
+
+			#title-label {
+				display: inline;
+				font-weight: bold;
+			}
+
+			d2l-input-textarea {
+				margin-bottom: 1rem;
+			}
+
+			d2l-button {
+				margin-right: 1rem;
+			}
+
+			.close-button {
+				left: auto;
+				position: absolute;
+				right: 0.6rem;
+				top: 0.6rem;
+			}
+
+			:host([dir="rtl"]) .close-button {
+				left: 0.6rem;
+				right: auto;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this.hideReason = false;
+		this.hideFeedback = false;
+		this._reason = '';
+	}
+
+	firstUpdated() {
+		super.firstUpdated();
+		this._setFocus();
+	}
+
+	render() {
+		return html`
+			<div class="opt-out-modal-fade"></div>
+			<div class="dialog" role="dialog" aria-labelledby="title-label">
+				<span tabindex="0" @focus="${this._shiftToLast}"></span>
+				<label id="title-label">${this.localize('components:optInFlyout:feedbackTitle')}</label>
+				<br><br>
+				<div ?hidden="${this.hideReason}">
+					<label id="reason-label">${this.localize('components:optInFlyout:feedbackReasonLabel')}</label>
+					<opt-out-reason-selector id="reason-selector" aria-labelledby="reason-label" @selected="${this._handleSelected}">
+						<slot></slot>
+					</opt-out-reason-selector>
+				</div>
+				<div ?hidden="${this.hideFeedback}">
+					<label id="feedback-label">${this.localize('components:optInFlyout:feedbackLabel')}</label>
+					<d2l-input-textarea id="feedback" labelled-by="feedback-label" rows="4" max-rows="4"></d2l-input-textarea>
+				</div>
+				<div>
+					<d2l-button id="done-button" primary="" @click="${this._confirm}">${this.localize('components:optInFlyout:done')}</d2l-button>
+					<d2l-button @click="${this._cancel}">${this.localize('components:optInFlyout:cancel')}</d2l-button>
+				</div>
+				<d2l-button-icon icon="tier1:close-small" id="close-button" class="close-button" @click="${this._cancel}" text="${this.localize('components:optInFlyout:close')}"></d2l-button-icon>
+				<span tabindex="0" @focus="${this._shiftToFirst}"></span>
+			</div>
+		`;
+	}
+
+	_cancel() {
+		this.dispatchEvent(new CustomEvent('cancel', defaultEventProperties));
+	}
+
+	_confirm() {
+		if (!this.shadowRoot) {
+			return;
+		}
+
+		const feedback = this.shadowRoot.querySelector('#feedback');
+
+		this.dispatchEvent(
+			new CustomEvent('confirm', {
+				detail: {
+					reason: this._reason || '',
+					feedback: (feedback && feedback.value || '').trim()
+				},
+				...defaultEventProperties
+			})
+		);
+	}
+
+	_handleSelected(e) {
+		this._reason = e.detail.value;
+	}
+
+	_setFocus() {
+		if (!this.shadowRoot) {
+			return;
+		}
+
+		let element;
+
+		if (!this.hideReason) {
+			element = this.shadowRoot.querySelector('#reason-selector');
+		} else if (!this.hideFeedback) {
+			element = this.shadowRoot.querySelector('#feedback');
+		} else {
+			element = this.shadowRoot.querySelector('#done-button');
+		}
+
+		if (!element) {
+			return;
+		}
+
+		element.focus();
+	}
+
+	_shiftToFirst() {
+		this._setFocus();
+	}
+
+	_shiftToLast() {
+		if (!this.shadowRoot) {
+			return;
+		}
+
+		const element = this.shadowRoot.querySelector('#close-button');
+
+		if (!element) {
+			return;
+		}
+
+		element.focus();
+	}
+
+}
+
+customElements.define('d2l-opt-out-dialog', OptOutDialog);

--- a/src/components/opt-in-flyout/opt-out-dialog.js
+++ b/src/components/opt-in-flyout/opt-out-dialog.js
@@ -115,9 +115,9 @@ class OptOutDialog extends composeMixins(
 				<br><br>
 				<div ?hidden="${this.hideReason}">
 					<label id="reason-label">${this.localize('components:optInFlyout:feedbackReasonLabel')}</label>
-					<opt-out-reason-selector id="reason-selector" aria-labelledby="reason-label" @selected="${this._handleSelected}">
+					<d2l-labs-opt-out-reason-selector id="reason-selector" aria-labelledby="reason-label" @selected="${this._handleSelected}">
 						<slot></slot>
-					</opt-out-reason-selector>
+					</d2l-labs-opt-out-reason-selector>
 				</div>
 				<div ?hidden="${this.hideFeedback}">
 					<label id="feedback-label">${this.localize('components:optInFlyout:feedbackLabel')}</label>
@@ -201,4 +201,4 @@ class OptOutDialog extends composeMixins(
 
 }
 
-customElements.define('d2l-opt-out-dialog', OptOutDialog);
+customElements.define('d2l-labs-opt-out-dialog', OptOutDialog);

--- a/src/components/opt-in-flyout/opt-out-flyout.js
+++ b/src/components/opt-in-flyout/opt-out-flyout.js
@@ -1,0 +1,82 @@
+import '@brightspace-ui/core/components/typography/typography.js';
+import './flyout-impl.js';
+import { css, html, LitElement } from 'lit';
+
+class OptOutFlyout extends LitElement {
+
+	static get properties() {
+		return {
+			open: { type: Boolean, reflect: true },
+			title: { type: String },
+			shortDescription: { type: String, attribute: 'short-description' },
+			longDescription: { type: String, attribute: 'long-description' },
+			tabPosition: { type: String, attribute: 'tab-position' },
+			noTransform: { type: Boolean, attribute: 'no-transform' },
+			tutorialLink: { type: String, attribute: 'tutorial-link' },
+			helpDocsLink: { type: String, attribute: 'help-docs-link' },
+			hideReason: { type: Boolean, attribute: 'hide-reason' },
+			hideFeedback: { type: Boolean, attribute: 'hide-feedback' }
+		};
+	}
+
+	static get styles() {
+		return css`
+			flyout-impl {
+				font-size: 20px;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this.open = false;
+	}
+
+	render() {
+		return html`
+			<flyout-impl
+				id="flyout-impl"
+				class="d2l-typography"
+				opt-out
+				title="${this.title}"
+				short-description="${this.shortDescription}"
+				long-description="${this.longDescription}"
+				tab-position="${this.tabPosition}"
+				tutorial-link="${this.tutorialLink}"
+				help-docs-link="${this.helpDocsLink}"
+				?hide-reason="${this.hideReason}"
+				?hide-feedback="${this.hideFeedback}"
+				?no-transform="${this.noTransform}"
+				?open="${this.open}"
+				@flyout-opened="${this._handleOpened}"
+				@flyout-closed="${this._handleClosed}">
+				<slot></slot>
+			</flyout-impl>
+		`;
+	}
+
+	focus() {
+		if (!this.shadowRoot) {
+			return;
+		}
+
+		const element = this.shadowRoot.querySelector('flyout-impl');
+
+		if (!element) {
+			return;
+		}
+
+		element.focus();
+	}
+
+	_handleClosed() {
+		this.open = false;
+	}
+
+	_handleOpened() {
+		this.open = true;
+	}
+
+}
+
+customElements.define('d2l-opt-out-flyout', OptOutFlyout);

--- a/src/components/opt-in-flyout/opt-out-flyout.js
+++ b/src/components/opt-in-flyout/opt-out-flyout.js
@@ -21,7 +21,7 @@ class OptOutFlyout extends LitElement {
 
 	static get styles() {
 		return css`
-			flyout-impl {
+			d2l-labs-opt-in-flyout-impl {
 				font-size: 20px;
 			}
 		`;
@@ -34,7 +34,7 @@ class OptOutFlyout extends LitElement {
 
 	render() {
 		return html`
-			<flyout-impl
+			<d2l-labs-opt-in-flyout-impl
 				id="flyout-impl"
 				class="d2l-typography"
 				opt-out
@@ -51,7 +51,7 @@ class OptOutFlyout extends LitElement {
 				@flyout-opened="${this._handleOpened}"
 				@flyout-closed="${this._handleClosed}">
 				<slot></slot>
-			</flyout-impl>
+			</d2l-labs-opt-in-flyout-impl>
 		`;
 	}
 
@@ -60,7 +60,7 @@ class OptOutFlyout extends LitElement {
 			return;
 		}
 
-		const element = this.shadowRoot.querySelector('flyout-impl');
+		const element = this.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 
 		if (!element) {
 			return;
@@ -79,4 +79,4 @@ class OptOutFlyout extends LitElement {
 
 }
 
-customElements.define('d2l-opt-out-flyout', OptOutFlyout);
+customElements.define('d2l-labs-opt-out-flyout', OptOutFlyout);

--- a/src/components/opt-in-flyout/opt-out-reason-selector.js
+++ b/src/components/opt-in-flyout/opt-out-reason-selector.js
@@ -85,7 +85,7 @@ class OptOutReasonSelector extends composeMixins(
 
 	_onSlotChanged() {
 		/* Passing <option> elements directly into a <select> tag with a slot doesn't work.
-		 * Instead, pass in <d2l-opt-out-reason> elements, and this component will construct
+		 * Instead, pass in <d2l-labs-opt-out-reason> elements, and this component will construct
 		 * the options from the passed in options.
 		 */
 		const selector = this.shadowRoot.querySelector('#selector');
@@ -97,7 +97,7 @@ class OptOutReasonSelector extends composeMixins(
 
 		children = children.filter(child =>
 			child &&
-			child.tagName === 'D2L-OPT-OUT-REASON' &&
+			child.tagName === 'd2l-labs-opt-out-reason' &&
 			child.key &&
 			child.text
 		).map(child => ({
@@ -146,4 +146,4 @@ class OptOutReasonSelector extends composeMixins(
 
 }
 
-customElements.define('opt-out-reason-selector', OptOutReasonSelector);
+customElements.define('d2l-labs-opt-out-reason-selector', OptOutReasonSelector);

--- a/src/components/opt-in-flyout/opt-out-reason-selector.js
+++ b/src/components/opt-in-flyout/opt-out-reason-selector.js
@@ -97,7 +97,7 @@ class OptOutReasonSelector extends composeMixins(
 
 		children = children.filter(child =>
 			child &&
-			child.tagName === 'd2l-labs-opt-out-reason' &&
+			child.tagName === 'D2L-LABS-OPT-OUT-REASON' &&
 			child.key &&
 			child.text
 		).map(child => ({

--- a/src/components/opt-in-flyout/opt-out-reason-selector.js
+++ b/src/components/opt-in-flyout/opt-out-reason-selector.js
@@ -1,0 +1,149 @@
+import './opt-out-reason.js';
+import { css, html, LitElement } from 'lit';
+import { composeMixins } from '@brightspace-ui/core/helpers/composeMixins.js';
+import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
+import { LocalizeLabsElement } from '../localize-labs-element.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+
+class OptOutReasonSelector extends composeMixins(
+	LitElement,
+	LocalizeLabsElement,
+	RtlMixin
+) {
+	static get properties() {
+		return {
+			_reasons: { state: true }
+		};
+	}
+
+	static get styles() {
+		return [
+			inputStyles,
+			css`
+				select {
+					-moz-appearance: none;
+					-webkit-appearance: none;
+					appearance: none;
+					background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23f2f3f5%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+					background-position: right center;
+					background-repeat: no-repeat;
+					background-size: contain;
+					display: block;
+					margin-bottom: 1.5rem !important;
+					position: relative;
+					width: 80%;
+				}
+
+				/* for ie11 - avoid displaying default select arrow */
+				select::-ms-expand {
+					display: none;
+				}
+
+				/* for ie11 - prevent background box from covering select arrow */
+				select::-ms-value {
+					background-color: transparent;
+					color: var(--d2l-input-color);
+				}
+
+				:host([dir="rtl"]) select {
+					background-position: left center !important;
+				}
+
+				#options {
+					display: none;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this._reasons = [];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this._onSlotChanged();
+	}
+
+	render() {
+		return html`
+			<select class="d2l-input" id="selector" @change="${this._reasonSelected}" onload="${this.focus()}">
+				<option disabled="" value="">${this.localize('components:optInFlyout:feedbackChooseReason')}</option>
+				${this._reasons.map((item) => html`<option value="${item.key}">${item.text}</option>`)}
+				<option value="Other">${this.localize('components:optInFlyout:feedbackReasonOther')}</option>
+			</select>
+			<div id="options">
+				<slot id="options-slot" @slotchange="${this._onSlotChanged}"></slot>
+			</div>
+		`;
+	}
+
+	focus() {
+		this.shadowRoot.querySelector('#selector')?.focus();
+	}
+
+	_onSlotChanged() {
+		/* Passing <option> elements directly into a <select> tag with a slot doesn't work.
+		 * Instead, pass in <d2l-opt-out-reason> elements, and this component will construct
+		 * the options from the passed in options.
+		 */
+		const selector = this.shadowRoot.querySelector('#selector');
+		if (!selector) {
+			return;
+		}
+		selector.selectedIndex = 0;
+		let children = this.shadowRoot.querySelector('#options-slot')?.assignedNodes({ flatten: true });
+
+		children = children.filter(child =>
+			child &&
+			child.tagName === 'D2L-OPT-OUT-REASON' &&
+			child.key &&
+			child.text
+		).map(child => ({
+			key: child.key,
+			text: child.text
+		}));
+
+		if (children.length <= 0) {
+			// Use default options if no valid options were provided
+			children = [
+				{ key: 'PreferOldExperience', text: this.localize('components:optInFlyout:feedbackReasonPreferOldExperience') },
+				{ key: 'MissingFeature', text: this.localize('components:optInFlyout:feedbackReasonMissingFeature') },
+				{ key: 'NotReadyForSomethingNew', text: this.localize('components:optInFlyout:feedbackReasonNotReadyForSomethingNew') },
+				{ key: 'JustCheckingSomething', text: this.localize('components:optInFlyout:feedbackReasonJustCheckingSomething') }
+			];
+		}
+
+		this._reasons = children;
+	}
+
+	_reasonSelected() {
+		const selectionIndex = this.shadowRoot.querySelector('#selector').selectedIndex;
+		if (selectionIndex < 1) {
+			this._setSelectedReason(null);
+			return;
+		}
+
+		const selection = this.shadowRoot.querySelector('#selector').options[selectionIndex];
+		if (!selection || !selection.value) {
+			this._setSelectedReason(null);
+			return;
+		}
+
+		this._setSelectedReason(selection.value);
+	}
+
+	_setSelectedReason(value) {
+		this.dispatchEvent(
+			new CustomEvent('selected', {
+				bubbles: true,
+				composed: true,
+				detail: { value }
+			})
+		);
+	}
+
+}
+
+customElements.define('opt-out-reason-selector', OptOutReasonSelector);

--- a/src/components/opt-in-flyout/opt-out-reason.js
+++ b/src/components/opt-in-flyout/opt-out-reason.js
@@ -1,0 +1,22 @@
+import { css, LitElement } from 'lit';
+
+class OptOutReason extends LitElement {
+
+	static get properties() {
+		return {
+			key: { type: String },
+			text: { type: String }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: none;
+			}
+		`;
+	}
+
+}
+
+customElements.define('d2l-opt-out-reason', OptOutReason);

--- a/src/components/opt-in-flyout/opt-out-reason.js
+++ b/src/components/opt-in-flyout/opt-out-reason.js
@@ -19,4 +19,4 @@ class OptOutReason extends LitElement {
 
 }
 
-customElements.define('d2l-opt-out-reason', OptOutReason);
+customElements.define('d2l-labs-opt-out-reason', OptOutReason);

--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -1,4 +1,22 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "إلغاء",
+	"components:optInFlyout:close": "إغلاق مربع الحوار هذا",
+	"components:optInFlyout:done": "تم",
+	"components:optInFlyout:feedbackChooseReason": "-- يُرجى اختيار سبب --",
+	"components:optInFlyout:feedbackLabel": "ما الذي يمكننا القيام به لتتشوّق إلى استخدام خدمتنا؟",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "أرجع للتحقّق من أمر ما فحسب",
+	"components:optInFlyout:feedbackReasonLabel": "هلا أخبرتنا بسبب رجوعك إلى الإصدار القديم؟",
+	"components:optInFlyout:feedbackReasonMissingFeature": "لا يتضمّن ميزة أستخدمها",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "ليس الوقت مناسبًا لتجربة هذا الإصدار",
+	"components:optInFlyout:feedbackReasonOther": "غير ذلك",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "أعتقد أن الإصدار القديم يوفر تجربة أفضل",
+	"components:optInFlyout:helpMessage": "اقرأ *مستندات التعليمات* الخاصة بنا للبدء!",
+	"components:optInFlyout:leaveOff": "الاستمرار في إيقاف التشغيل",
+	"components:optInFlyout:leaveOn": "الاستمرار في التشغيل",
+	"components:optInFlyout:openOptIn": "فتح مربع حوار الاشتراك",
+	"components:optInFlyout:openOptOut": "فتح مربع حوار إلغاء الاشتراك",
+	"components:optInFlyout:tutorialAndHelpMessage": "شاهد *الدروس التعليمية* الخاصة بنا أو اقرأ ~مستندات التعليمات الخاصة بنا~ للبدء!",
+	"components:optInFlyout:tutorialMessage": "شاهد *الدروس التعليمية* الخاصة بنا لمساعدتك على البدء!",
+	"components:optInFlyout:turnOff": "إيقاف التشغيل",
+	"components:optInFlyout:turnOn": "التشغيل"
 };

--- a/src/lang/cy.js
+++ b/src/lang/cy.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Canslo",
+	"components:optInFlyout:close": "Cau’r deialog hwn",
+	"components:optInFlyout:done": "Wedi Gorffen",
+	"components:optInFlyout:feedbackChooseReason": "-- Dewiswch reswm --",
+	"components:optInFlyout:feedbackLabel": "Beth allwn ni ei wneud i droi hwn yn rhywbeth y byddech chi’n dwlu ar ei ddefnyddio?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Dim ond yn newid yn ôl i wirio rhywbeth",
+	"components:optInFlyout:feedbackReasonLabel": "A fyddech cystal â rhoi gwybod i ni pam eich bod yn newid yn ôl?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Mae nodwedd rydw i’n ei defnyddio ar goll",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Nid yw’n amser da i fi roi cynnig ar y fersiwn hwn",
+	"components:optInFlyout:feedbackReasonOther": "Arall",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Rwy’n meddwl fod yr hen fersiwn yn brofiad gwell",
+	"components:optInFlyout:feedbackTitle": "Rhowch wybod i ni sut gallwn wella!",
+	"components:optInFlyout:helpMessage": "Darllenwch ein *dogfennaeth cymorth* i gychwyn arni!",
+	"components:optInFlyout:leaveOff": "Gadewch e bant",
+	"components:optInFlyout:leaveOn": "Gadewch e ymlaen",
+	"components:optInFlyout:openOptIn": "Agor y deialog optio i mewn",
+	"components:optInFlyout:openOptOut": "Agor y deialog optio allan",
+	"components:optInFlyout:turnOff": "Diffoddwch e",
+	"components:optInFlyout:turnOn": "Trowch e ymlaen",
+	"components:optInFlyout:tutorialAndHelpMessage": "Gwyliwch ein *tiwtorialau* neu darllenwch ein ~dogfennaeth cymorth~ i gychwyn arni!",
+	"components:optInFlyout:tutorialMessage": "Gwyliwch ein *tiwtorialau* i’ch helpu i gychwyn arni!"
 };

--- a/src/lang/da.js
+++ b/src/lang/da.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Annuller",
+	"components:optInFlyout:close": "Luk denne dialogboks",
+	"components:optInFlyout:done": "Udført",
+	"components:optInFlyout:feedbackChooseReason": "-- Vælg en årsag --",
+	"components:optInFlyout:feedbackLabel": "Hvad kan vi gøre, før dette bliver et produkt, du gerne vil bruge?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Jeg skifter tilbage for at tjekke noget",
+	"components:optInFlyout:feedbackReasonLabel": "Vil du fortælle os, hvorfor du skifter tilbage?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Der mangler en funktion, som jeg skal bruge",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Det er ikke et godt tidspunkt for mig at prøve denne version",
+	"components:optInFlyout:feedbackReasonOther": "Andet",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Jeg tror, at den gamle version er en bedre oplevelse",
+	"components:optInFlyout:feedbackTitle": "Fortæl os, hvordan vi kan gøre det bedre!",
+	"components:optInFlyout:helpMessage": "Læs vores *hjælp-dokumentation* for at komme i gang!",
+	"components:optInFlyout:leaveOff": "Lad den være slået fra",
+	"components:optInFlyout:leaveOn": "Lad den være slået til",
+	"components:optInFlyout:openOptIn": "Åbn tilmeldingsdialogboksen",
+	"components:optInFlyout:openOptOut": "Åbn udmeldelsesdialogboksen",
+	"components:optInFlyout:turnOff": "Slå den fra",
+	"components:optInFlyout:turnOn": "Slå den til",
+	"components:optInFlyout:tutorialAndHelpMessage": "Se vores *selvstudier*, eller læs vores ~hjælp-dokumentation~ for at komme i gang!",
+	"components:optInFlyout:tutorialMessage": "Se vores *selvstudier* for at komme i gang!"
 };

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Abbrechen",
+	"components:optInFlyout:close": "Dieses Dialogfeld schließen",
+	"components:optInFlyout:done": "Fertig",
+	"components:optInFlyout:feedbackChooseReason": "-- Bitte wählen Sie einen Grund --",
+	"components:optInFlyout:feedbackLabel": "Was können wir tun, damit Sie die neue Oberfläche gerne nutzen?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Ich schalte nur um, um etwas nachzusehen",
+	"components:optInFlyout:feedbackReasonLabel": "Würden Sie uns sagen, warum Sie wieder zurückwechseln?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Es fehlt eine Funktion, die ich nutze",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Es ist kein guter Zeitpunkt für mich, um diese Version auszuprobieren",
+	"components:optInFlyout:feedbackReasonOther": "Andere",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Ich finde, dass die alte Version ein besseres Erlebnis bietet",
+	"components:optInFlyout:feedbackTitle": "Sagen Sie uns, wie wir uns verbessern können!",
+	"components:optInFlyout:helpMessage": "Lesen Sie unsere *Hilfe-Dokumentation*, um zu beginnen!",
+	"components:optInFlyout:leaveOff": "Ausgeschaltet lassen",
+	"components:optInFlyout:leaveOn": "Eingeschaltet lassen",
+	"components:optInFlyout:openOptIn": "Aktivierungsdialog öffnen",
+	"components:optInFlyout:openOptOut": "Deaktivierungsdialog öffnen",
+	"components:optInFlyout:turnOff": "Ausschalten",
+	"components:optInFlyout:turnOn": "Einschalten",
+	"components:optInFlyout:tutorialAndHelpMessage": "Sehen Sie unsere *Tutorials* an, oder lesen Sie unsere ~Hilfe-Dokumentation~, um zu beginnen!",
+	"components:optInFlyout:tutorialMessage": "Unsere *Tutorials* helfen Ihnen beim Start!"
 };

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Cancel",
+	"components:optInFlyout:close": "Close this dialog",
+	"components:optInFlyout:done": "Done",
+	"components:optInFlyout:feedbackChooseReason": "-- Please choose a reason --",
+	"components:optInFlyout:feedbackLabel": "What could we do to make this something you'd love to use?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Just switching back to check something",
+	"components:optInFlyout:feedbackReasonLabel": "Would you mind telling us why you are switching back?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "It's missing a feature that I use",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "It's not a good time for me to try this version",
+	"components:optInFlyout:feedbackReasonOther": "Other",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "I think the old version is a better experience",
+	"components:optInFlyout:feedbackTitle": "Let us know how to improve!",
+	"components:optInFlyout:helpMessage": "Read our *help documentation* to get started!",
+	"components:optInFlyout:leaveOff": "Leave it off",
+	"components:optInFlyout:leaveOn": "Leave it on",
+	"components:optInFlyout:openOptIn": "Open the opt-in dialog",
+	"components:optInFlyout:openOptOut": "Open the opt-out dialog",
+	"components:optInFlyout:turnOff": "Turn it off",
+	"components:optInFlyout:turnOn": "Turn it on",
+	"components:optInFlyout:tutorialAndHelpMessage": "Watch our *tutorials* or read our ~help documentation~ to get started!",
+	"components:optInFlyout:tutorialMessage": "Watch our *tutorials* to help you get started!"
 };

--- a/src/lang/es-es.js
+++ b/src/lang/es-es.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Cancelar",
+	"components:optInFlyout:close": "Cerrar este cuadro de diálogo",
+	"components:optInFlyout:done": "Listo",
+	"components:optInFlyout:feedbackChooseReason": "-- Seleccione un motivo --",
+	"components:optInFlyout:feedbackLabel": "¿Qué podríamos hacer para que esto sea algo que le encantaría utilizar?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Quiero volver atrás a verificar algo",
+	"components:optInFlyout:feedbackReasonLabel": "¿Le importaría decirnos por qué desea volver atrás?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Falta una función que utilizo",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "No es un buen momento para probar esta versión",
+	"components:optInFlyout:feedbackReasonOther": "Otro",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Creo que la versión anterior proporciona una experiencia mejor",
+	"components:optInFlyout:feedbackTitle": "Háganos saber cómo podemos mejorar.",
+	"components:optInFlyout:helpMessage": "¡Lea nuestra *documentación de ayuda* para comenzar!",
+	"components:optInFlyout:leaveOff": "Mantener desactivado",
+	"components:optInFlyout:leaveOn": "Mantener activado",
+	"components:optInFlyout:openOptIn": "Abrir el cuadro de diálogo de suscripción",
+	"components:optInFlyout:openOptOut": "Abrir el cuadro de diálogo de anulación de suscripción",
+	"components:optInFlyout:turnOff": "Desactivar",
+	"components:optInFlyout:turnOn": "Activar",
+	"components:optInFlyout:tutorialAndHelpMessage": "Consulte nuestros *tutoriales* o lea nuestra ~documentación de ayuda~ para comenzar.",
+	"components:optInFlyout:tutorialMessage": "Consulte nuestros *tutoriales* como ayuda adicional para empezar."
 };

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Cancelar",
+	"components:optInFlyout:close": "Cerrar este cuadro de diálogo",
+	"components:optInFlyout:done": "Listo",
+	"components:optInFlyout:feedbackChooseReason": "-- Seleccione un motivo --",
+	"components:optInFlyout:feedbackLabel": "¿Qué podríamos hacer para que esto sea algo que le encantaría utilizar?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Quiero volver atrás a verificar algo",
+	"components:optInFlyout:feedbackReasonLabel": "¿Le importaría decirnos por qué desea volver atrás?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Falta una función que utilizo",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "No me parece un buen momento para probar esta versión",
+	"components:optInFlyout:feedbackReasonOther": "Otro",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Creo que la versión anterior ofrece una mejor experiencia",
+	"components:optInFlyout:feedbackTitle": "Háganos saber cómo podemos mejorar.",
+	"components:optInFlyout:helpMessage": "Lea nuestra *documentación de ayuda* para comenzar.",
+	"components:optInFlyout:leaveOff": "Mantenerla apagada",
+	"components:optInFlyout:leaveOn": "Mantenerla activada",
+	"components:optInFlyout:openOptIn": "Abrir cuadro de diálogo de suscripción",
+	"components:optInFlyout:openOptOut": "Abrir cuadro de diálogo de anulación de suscripción",
+	"components:optInFlyout:turnOff": "Desactivar",
+	"components:optInFlyout:turnOn": "Activar",
+	"components:optInFlyout:tutorialAndHelpMessage": "Vea nuestros *tutoriales* o lea nuestra ~documentación de ayuda~ para comenzar.",
+	"components:optInFlyout:tutorialMessage": "Vea nuestros *tutoriales* para saber cómo comenzar."
 };

--- a/src/lang/fr-fr.js
+++ b/src/lang/fr-fr.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Annuler",
+	"components:optInFlyout:close": "Fermer cette boîte de dialogue",
+	"components:optInFlyout:done": "Terminé",
+	"components:optInFlyout:feedbackChooseReason": "-- Choisissez un motif --",
+	"components:optInFlyout:feedbackLabel": "Que pourrions-nous améliorer pour que vous aimiez utiliser cette expérience ?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Je souhaite juste revenir en arrière pour effectuer des vérifications",
+	"components:optInFlyout:feedbackReasonLabel": "Pourriez-vous nous expliquer pourquoi vous êtes revenu à l’ancienne expérience ?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Il manque l’une des fonctionnalités que j’utilise",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Ce n’est pas le bon moment pour essayer cette version",
+	"components:optInFlyout:feedbackReasonOther": "Autre",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Je pense que l’ancienne version est une meilleure expérience",
+	"components:optInFlyout:feedbackTitle": "Dites-nous comment nous améliorer !",
+	"components:optInFlyout:helpMessage": "Consultez notre * documentation d’aide * pour commencer !",
+	"components:optInFlyout:leaveOff": "Laisser désactivé",
+	"components:optInFlyout:leaveOn": "Laisser actif",
+	"components:optInFlyout:openOptIn": "Ouvrir la boîte de dialogue d’adhésion",
+	"components:optInFlyout:openOptOut": "Ouvrir la boîte de dialogue d’annulation d’adhésion",
+	"components:optInFlyout:turnOff": "Désactiver",
+	"components:optInFlyout:turnOn": "Activer",
+	"components:optInFlyout:tutorialAndHelpMessage": "Regardez nos * tutoriels *ou lisez notre ~ documentation d’aide ~ pour commencer !",
+	"components:optInFlyout:tutorialMessage": "Regardez nos * tutoriels * pour vous aider à démarrer !"
 };

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Annuler",
+	"components:optInFlyout:close": "Fermer cette boîte de dialogue",
+	"components:optInFlyout:done": "Terminé",
+	"components:optInFlyout:feedbackChooseReason": "-- Veuillez choisir un motif --",
+	"components:optInFlyout:feedbackLabel": "Que pourrions-nous faire pour faire de cette interface une interface que vous adoreriez utiliser?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Je retourne en arrière pour vérifier quelque chose",
+	"components:optInFlyout:feedbackReasonLabel": "Pouvez-vous nous dire pourquoi vous retournez en arrière?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Une fonction que j’utilise me manque",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Ce n’est pas un bon moment pour essayer cette version.",
+	"components:optInFlyout:feedbackReasonOther": "Autre",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Je crois que l’ancienne version est une meilleure expérience",
+	"components:optInFlyout:feedbackTitle": "Dites-nous comment nous améliorer!",
+	"components:optInFlyout:helpMessage": "Lisez notre *documentation d’assistance* pour pouvoir débuter!",
+	"components:optInFlyout:leaveOff": "Laisser désactivé",
+	"components:optInFlyout:leaveOn": "Laisser activé",
+	"components:optInFlyout:openOptIn": "Ouvrir le dialogue d’adhésion",
+	"components:optInFlyout:openOptOut": "Ouvrir le dialogue de retrait",
+	"components:optInFlyout:turnOff": "Fermer",
+	"components:optInFlyout:turnOn": "Activer",
+	"components:optInFlyout:tutorialAndHelpMessage": "Découvrez nos *tutoriels* ou lisez notre ~documentation d’assistance~ pour pouvoir débuter!",
+	"components:optInFlyout:tutorialMessage": "Découvrez nos *tutoriels* pour vous aider à commencer du bon pied!"
 };

--- a/src/lang/hi.js
+++ b/src/lang/hi.js
@@ -1,0 +1,23 @@
+export default {
+	"components:optInFlyout:cancel": "रद्द करें",
+	"components:optInFlyout:close": "यह संवाद बंद करें",
+	"components:optInFlyout:done": "पूर्ण हो गया",
+	"components:optInFlyout:feedbackChooseReason": "-- कृपया कोई कारण चुनें --",
+	"components:optInFlyout:feedbackLabel": "इसे ऐसा कुछ बनाने के लिए हम क्या कर सकते हैं जिसका आप उपयोग करना पसंद करेंगे?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "कुछ जाँचने के लिए बस वापस स्विच करना है",
+	"components:optInFlyout:feedbackReasonLabel": "क्या आप हमें यह बताना चाहेंगे कि आप वापस स्विच क्यों कर रहे हैं?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "इसमें वह फ़ीचर नहीं है जिसका मैं उपयोग करता हूँ",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "इस संस्करण को आज़माने हेतु मेरे लिए यह समय अच्छा नहीं है",
+	"components:optInFlyout:feedbackReasonOther": "अन्य",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "मुझे लगता है कि पुराने वर्ज़न का अनुभव बेहतर है",
+	"components:optInFlyout:feedbackTitle": "हमें बताएँ कि कैसे सुधार करें!",
+	"components:optInFlyout:helpMessage": "शुरू करने के लिए हमारा *मदद दस्तावेज़* पढ़ें!",
+	"components:optInFlyout:leaveOff": "इसे बंद रहने दें",
+	"components:optInFlyout:leaveOn": "इसे चालू रहने दें",
+	"components:optInFlyout:openOptIn": "ऑप्ट-इन संवाद खोलें",
+	"components:optInFlyout:openOptOut": "ऑप्ट-आउट संवाद खोलें",
+	"components:optInFlyout:turnOff": "इसे बंद करें",
+	"components:optInFlyout:turnOn": "इसे चालू करें",
+	"components:optInFlyout:tutorialAndHelpMessage": "शुरू करने के लिए हमारे *ट्यूटोरियल* देखें या हमारे ~मदद दस्तावेज़~ पढ़ें!",
+	"components:optInFlyout:tutorialMessage": "शुरू करने में आपकी मदद के लिए हमारे *ट्यूटोरियल* देखें!"
+};

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "キャンセル",
+	"components:optInFlyout:close": "このダイアログを閉じる",
+	"components:optInFlyout:done": "終了",
+	"components:optInFlyout:feedbackChooseReason": "--理由を選択してください--",
+	"components:optInFlyout:feedbackLabel": "気に入っていただけるものにするには、どのような点を改善するとよいか、ご意見をお聞かせいただけると幸いです。",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "確認したいことがあるので戻すだけです",
+	"components:optInFlyout:feedbackReasonLabel": "元に戻した理由を教えていただけますか？",
+	"components:optInFlyout:feedbackReasonMissingFeature": "使用している機能がありません",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "今はタイミングが悪いのでこのバージョンを試すことはできない",
+	"components:optInFlyout:feedbackReasonOther": "その他",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "古いバージョンのほうが使いやすい",
+	"components:optInFlyout:feedbackTitle": "改善できる点についてご意見をお聞かせください。",
+	"components:optInFlyout:helpMessage": "はじめに*ヘルプドキュメント*をお読みください。",
+	"components:optInFlyout:leaveOff": "オフのままにする",
+	"components:optInFlyout:leaveOn": "オンのままにする",
+	"components:optInFlyout:openOptIn": "設定ダイアログを開く",
+	"components:optInFlyout:openOptOut": "オプトアウトダイアログを開く",
+	"components:optInFlyout:turnOff": "オフにする",
+	"components:optInFlyout:turnOn": "オンにする",
+	"components:optInFlyout:tutorialAndHelpMessage": "はじめに*チュートリアル*をご覧になるか、～ヘルプドキュメント～をお読みください。",
+	"components:optInFlyout:tutorialMessage": "ぜひ*チュートリアル*をご覧になり、ご利用を開始してください。"
 };

--- a/src/lang/ko.js
+++ b/src/lang/ko.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "취소",
+	"components:optInFlyout:close": "이 대화 상자 닫기",
+	"components:optInFlyout:done": "완료",
+	"components:optInFlyout:feedbackChooseReason": "-- 이유 선택 --",
+	"components:optInFlyout:feedbackLabel": "어떻게 하면 이 기능을 개선할 수 있겠습니까?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "확인할 사항이 있어 다시 전환합니다.",
+	"components:optInFlyout:feedbackReasonLabel": "다시 전환하는 이유를 알려주시겠습니까?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "내가 사용하는 기능이 없습니다.",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "이 버전을 사용해 보기에 적당한 시기가 아닙니다.",
+	"components:optInFlyout:feedbackReasonOther": "기타",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "이전 버전이 더 나은 경험을 제공한다고 생각합니다.",
+	"components:optInFlyout:feedbackTitle": "개선할 사항을 알려주십시오!",
+	"components:optInFlyout:helpMessage": "시작하려면 *도움말 설명서*를 읽어보십시오!",
+	"components:optInFlyout:leaveOff": "비활성화 유지",
+	"components:optInFlyout:leaveOn": "활성화 유지",
+	"components:optInFlyout:openOptIn": "옵트인 대화 상자 열기",
+	"components:optInFlyout:openOptOut": "옵트아웃 대화 상자 열기",
+	"components:optInFlyout:turnOff": "비활성화",
+	"components:optInFlyout:turnOn": "활성화",
+	"components:optInFlyout:tutorialAndHelpMessage": "시작하려면 *개별지도*를 시청하거나 ~도움말 설명서~를 읽어보십시오!",
+	"components:optInFlyout:tutorialMessage": "시작하는 데 도움이 되는 *개별지도*를 시청하십시오."
 };

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Annuleren",
+	"components:optInFlyout:close": "Dit dialoogvenster sluiten",
+	"components:optInFlyout:done": "Gereed",
+	"components:optInFlyout:feedbackChooseReason": "-- Kies een reden --",
+	"components:optInFlyout:feedbackLabel": "Wat moeten we veranderen om dit voor u een interessante omgeving te maken?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Even teruggaan om iets te controleren",
+	"components:optInFlyout:feedbackReasonLabel": "Wilt u ons vertellen waarom u teruggaat naar de vorige versie?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Er ontbreekt een functie die ik gebruik",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Ik wil deze versie op dit moment niet uitproberen",
+	"components:optInFlyout:feedbackReasonOther": "Overig",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Ik vind dat de oude versie een betere ervaring biedt",
+	"components:optInFlyout:feedbackTitle": "Laat ons weten wat we kunnen verbeteren.",
+	"components:optInFlyout:helpMessage": "Lees onze *helpdocumentatie* om aan de slag te gaan.",
+	"components:optInFlyout:leaveOff": "Uitgeschakeld laten",
+	"components:optInFlyout:leaveOn": "Ingeschakeld laten",
+	"components:optInFlyout:openOptIn": "Het dialoogvenster voor aanmelden openen",
+	"components:optInFlyout:openOptOut": "Het dialoogvenster voor terugtrekken openen",
+	"components:optInFlyout:turnOff": "Uitschakelen",
+	"components:optInFlyout:turnOn": "Inschakelen",
+	"components:optInFlyout:tutorialAndHelpMessage": "Lees onze *zelfstudies* of onze ~helpdocumentatie~ om aan de slag te gaan.",
+	"components:optInFlyout:tutorialMessage": "Bekijk onze *zelfstudies* om aan de slag te gaan."
 };

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Cancelar",
+	"components:optInFlyout:close": "Fechar esta caixa de diálogo",
+	"components:optInFlyout:done": "Concluído",
+	"components:optInFlyout:feedbackChooseReason": "-- Escolha um motivo --",
+	"components:optInFlyout:feedbackLabel": "O que podemos fazer para que você adore usar esta interface?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Só voltei opção para verificar algo",
+	"components:optInFlyout:feedbackReasonLabel": "Você se incomodaria em nos informar por que voltou?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Falta um recurso que utilizo",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Não é um bom momento para testar essa versão",
+	"components:optInFlyout:feedbackReasonOther": "Outro",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Acredito que a versão antiga proporciona uma melhor experiência",
+	"components:optInFlyout:feedbackTitle": "Diga-nos como melhorar!",
+	"components:optInFlyout:helpMessage": "Leia a nossa *documentação de ajuda* para começar!",
+	"components:optInFlyout:leaveOff": "Deixar desativada",
+	"components:optInFlyout:leaveOn": "Deixar ativado",
+	"components:optInFlyout:openOptIn": "Abrir caixa de diálogo Aceitar",
+	"components:optInFlyout:openOptOut": "Abrir caixa de diálogo Recusar",
+	"components:optInFlyout:turnOff": "Desligar",
+	"components:optInFlyout:turnOn": "Ativar",
+	"components:optInFlyout:tutorialAndHelpMessage": "Assista aos nossos *tutoriais* ou leia a nossa ~documentação de ajuda~ para começar!",
+	"components:optInFlyout:tutorialMessage": "Assista aos nossos *tutoriais* para ajudar você a começar!"
 };

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "Avbryt",
+	"components:optInFlyout:close": "Stäng dialogrutan",
+	"components:optInFlyout:done": "Klar",
+	"components:optInFlyout:feedbackChooseReason": "-- Välj anledning --",
+	"components:optInFlyout:feedbackLabel": "Vad kan vi göra för att du ska vilja använda det här?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Byter tillbaka för att kontrollera en sak",
+	"components:optInFlyout:feedbackReasonLabel": "Varför byter du tillbaka?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "En funktion som jag använder saknas",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Det är inte ett bra tillfälle för mig att prova den här versionen",
+	"components:optInFlyout:feedbackReasonOther": "Annat",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Jag tycker att den gamla versionen ger en bättre upplevelse",
+	"components:optInFlyout:feedbackTitle": "Vad kan vi göra för att bli bättre?",
+	"components:optInFlyout:helpMessage": "Läs vår *hjälpdokumentation* för att komma igång!",
+	"components:optInFlyout:leaveOff": "Lämna av",
+	"components:optInFlyout:leaveOn": "Låt den vara på",
+	"components:optInFlyout:openOptIn": "Öppna dialogrutan för anmälan",
+	"components:optInFlyout:openOptOut": "Öppna dialogrutan för avanmälan",
+	"components:optInFlyout:turnOff": "Stäng av",
+	"components:optInFlyout:turnOn": "Sätt på",
+	"components:optInFlyout:tutorialAndHelpMessage": "Se våra *handledningar* eller läs vår ~hjälpdokumentation~ för att komma igång!",
+	"components:optInFlyout:tutorialMessage": "Se våra *handledningar* som hjälper dig att komma igång!"
 };

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "İptal Et",
+	"components:optInFlyout:close": "Bu iletişim kutusunu kapat",
+	"components:optInFlyout:done": "Bitti",
+	"components:optInFlyout:feedbackChooseReason": "-- Lütfen bir sebep seçin --",
+	"components:optInFlyout:feedbackLabel": "Bunu kullanmayı sevmeniz için ne yapabiliriz?",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "Sadece bir şeyi kontrol etmek için geri dönüyorum",
+	"components:optInFlyout:feedbackReasonLabel": "Neden geri döndüğünüzü bizimle paylaşabilir misiniz?",
+	"components:optInFlyout:feedbackReasonMissingFeature": "Kullandığım bir özellik burada mevcut değil",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "Şu an benim için bu sürümü denemeye uygun bir zaman değil",
+	"components:optInFlyout:feedbackReasonOther": "Diğer",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "Eski sürümün daha iyi bir deneyim sunduğunu düşünüyorum",
+	"components:optInFlyout:feedbackTitle": "Nasıl iyileştirilebileceğini bize bildirin!",
+	"components:optInFlyout:helpMessage": "\"Yardım belgemizi* okuyarak başlayın!",
+	"components:optInFlyout:leaveOff": "Kapalı bırak",
+	"components:optInFlyout:leaveOn": "Açık bırak",
+	"components:optInFlyout:openOptIn": "Seçili olan diyaloğu aç",
+	"components:optInFlyout:openOptOut": "Seçili olmayan diyaloğu aç",
+	"components:optInFlyout:turnOff": "Kapat",
+	"components:optInFlyout:turnOn": "Aç",
+	"components:optInFlyout:tutorialAndHelpMessage": "*Eğitimlerimizi\" izleyerek ya da ~yardım belgemizi~ okuyarak başlayın!",
+	"components:optInFlyout:tutorialMessage": "Başlamanıza yardımcı olacak *eğitimlerimizi* izleyin!"
 };

--- a/src/lang/zh-cn.js
+++ b/src/lang/zh-cn.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "取消",
+	"components:optInFlyout:close": "关闭此对话框",
+	"components:optInFlyout:done": "完成",
+	"components:optInFlyout:feedbackChooseReason": "-- 请选择原因 --",
+	"components:optInFlyout:feedbackLabel": "我们可以做些什么来改善您的使用体验？",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "只是切换回来检查一下",
+	"components:optInFlyout:feedbackReasonLabel": "您是否介意告诉我们您要切换回去的原因？",
+	"components:optInFlyout:feedbackReasonMissingFeature": "缺少我要使用的功能",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "现在并不是我试用这个版本的好时机",
+	"components:optInFlyout:feedbackReasonOther": "其他",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "我认为旧版本的体验更好",
+	"components:optInFlyout:feedbackTitle": "请让我们知道如何改进！",
+	"components:optInFlyout:helpMessage": "阅读我们的*帮助文档*以便快速入门！",
+	"components:optInFlyout:leaveOff": "保持关闭",
+	"components:optInFlyout:leaveOn": "保持开启",
+	"components:optInFlyout:openOptIn": "打开选择加入对话框",
+	"components:optInFlyout:openOptOut": "打开选择退出对话框",
+	"components:optInFlyout:turnOff": "关闭",
+	"components:optInFlyout:turnOn": "开启",
+	"components:optInFlyout:tutorialAndHelpMessage": "观看我们的*教程*或阅读我们的~帮助文档~，以便快速入门！",
+	"components:optInFlyout:tutorialMessage": "观看我们的*教程*帮助您快速入门！"
 };

--- a/src/lang/zh-tw.js
+++ b/src/lang/zh-tw.js
@@ -1,4 +1,23 @@
-/* eslint quotes: 0 */
-
 export default {
+	"components:optInFlyout:cancel": "取消",
+	"components:optInFlyout:close": "關閉此對話方塊",
+	"components:optInFlyout:done": "完成",
+	"components:optInFlyout:feedbackChooseReason": "-- 請選擇一個原因 --",
+	"components:optInFlyout:feedbackLabel": "我們應如何改善讓您變得喜歡使用？",
+	"components:optInFlyout:feedbackReasonJustCheckingSomething": "只是切換回來檢查一些東西",
+	"components:optInFlyout:feedbackReasonLabel": "是否能告知我們您切換回來的原因？",
+	"components:optInFlyout:feedbackReasonMissingFeature": "內容缺少我會用到的功能",
+	"components:optInFlyout:feedbackReasonNotReadyForSomethingNew": "目前不是試用這個版本的好時機",
+	"components:optInFlyout:feedbackReasonOther": "其他",
+	"components:optInFlyout:feedbackReasonPreferOldExperience": "我覺得舊版的使用體驗更好",
+	"components:optInFlyout:feedbackTitle": "如有待改進之處，請不吝告知！",
+	"components:optInFlyout:helpMessage": "閱讀我們的 *說明文件* 以開始使用！",
+	"components:optInFlyout:leaveOff": "保持關閉",
+	"components:optInFlyout:leaveOn": "保持開啟",
+	"components:optInFlyout:openOptIn": "開啟選擇加入對話方塊",
+	"components:optInFlyout:openOptOut": "開啟選擇退出對話方塊",
+	"components:optInFlyout:turnOff": "關閉",
+	"components:optInFlyout:turnOn": "開啟",
+	"components:optInFlyout:tutorialAndHelpMessage": "觀看我們的 *教學課程* 或閱讀 ~說明文件~ 以開始使用！",
+	"components:optInFlyout:tutorialMessage": "觀看我們的 *教學課程*，協助您開始使用！"
 };

--- a/test/components/opt-in-flyout/opt-in-flyout.test.js
+++ b/test/components/opt-in-flyout/opt-in-flyout.test.js
@@ -2,15 +2,15 @@ import '../../../src/components/opt-in-flyout/opt-in-flyout.js';
 import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import TestUtil from './utilities.js';
 
-describe('d2l-opt-in-flyout', () => {
+describe('d2l-labs-opt-in-flyout', () => {
 
 	describe('defaults', () => {
 
 		let flyout, innerFlyout;
 
 		beforeEach(async() => {
-			flyout = await fixture(html`<d2l-opt-in-flyout open></d2l-opt-in-flyout>`);
-			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			flyout = await fixture(html`<d2l-labs-opt-in-flyout open></d2l-labs-opt-in-flyout>`);
+			innerFlyout = flyout.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 		});
 
 		it('should not contain short description', () => {
@@ -36,16 +36,16 @@ describe('d2l-opt-in-flyout', () => {
 
 		beforeEach(async() => {
 			flyout = await fixture(html`
-				<d2l-opt-in-flyout
+				<d2l-labs-opt-in-flyout
 					open
 					title="Flyout Demo"
 					short-description="This is a short description"
 					long-description="This is a long description"
 					tab-position="right"
 					tutorial-link="https://www.testlink1.com"
-					help-docs-link="https://www.testlink2.com"></d2l-opt-in-flyout>
+					help-docs-link="https://www.testlink2.com"></d2l-labs-opt-in-flyout>
 			`);
-			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			innerFlyout = flyout.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 		});
 
 		it('should contain short description', () => {
@@ -168,8 +168,8 @@ describe('d2l-opt-in-flyout', () => {
 		let flyout, innerFlyout;
 
 		beforeEach(async() => {
-			flyout = await fixture(html`<d2l-opt-in-flyout></d2l-opt-in-flyout>`);
-			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			flyout = await fixture(html`<d2l-labs-opt-in-flyout></d2l-labs-opt-in-flyout>`);
+			innerFlyout = flyout.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 		});
 
 		it('should fire flyout-opened event when tab clicked', async() => {

--- a/test/components/opt-in-flyout/opt-in-flyout.test.js
+++ b/test/components/opt-in-flyout/opt-in-flyout.test.js
@@ -1,0 +1,183 @@
+import '../../../src/components/opt-in-flyout/opt-in-flyout.js';
+import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import TestUtil from './utilities.js';
+
+describe('d2l-opt-in-flyout', () => {
+
+	describe('defaults', () => {
+
+		let flyout, innerFlyout;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`<d2l-opt-in-flyout open></d2l-opt-in-flyout>`);
+			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+		});
+
+		it('should not contain short description', () => {
+			const shortDescription = innerFlyout.shadowRoot.querySelector('#short-description');
+			expect(shortDescription).to.not.exist;
+		});
+
+		it('should not contain long description', () => {
+			const longDescription = innerFlyout.shadowRoot.querySelector('#long-description');
+			expect(longDescription).to.not.exist;
+		});
+
+		it('should not contain tutorial link or help documentation if not set', () => {
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			expect(tutorial).to.not.exist;
+		});
+
+	});
+
+	describe('properties specified', () => {
+
+		let flyout, innerFlyout;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`
+				<d2l-opt-in-flyout
+					open
+					title="Flyout Demo"
+					short-description="This is a short description"
+					long-description="This is a long description"
+					tab-position="right"
+					tutorial-link="https://www.testlink1.com"
+					help-docs-link="https://www.testlink2.com"></d2l-opt-in-flyout>
+			`);
+			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+		});
+
+		it('should contain short description', () => {
+			const shortDescription = innerFlyout.shadowRoot.querySelector('#short-description');
+			expect(shortDescription).to.exist;
+		});
+
+		it('should contain title', () => {
+			const title = innerFlyout.shadowRoot.querySelector('#title');
+			expect(title.textContent).to.equal('Flyout Demo');
+		});
+
+		it('should reflect title attribute to property', async() => {
+			const newTitle = 'new title';
+			flyout.setAttribute('title', newTitle);
+			await flyout.updateComplete;
+			await innerFlyout.updateComplete;
+			expect(flyout.title).to.equal(newTitle);
+			const title = innerFlyout.shadowRoot.querySelector('#title');
+			expect(title.textContent).to.equal(newTitle);
+		});
+
+		it('should contain long description', () => {
+			const longDescription = innerFlyout.shadowRoot.querySelector('#long-description');
+			expect(longDescription).to.exist;
+		});
+
+		it('should contain tutorial link', () => {
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(2);
+
+			expect(links[0].href).to.contain('https://www.testlink1.com');
+			expect(links[0].textContent).to.contain('tutorials');
+		});
+
+		it('should contain help documentation link', () => {
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(2);
+
+			expect(links[1].href).to.contain('https://www.testlink2.com');
+			expect(links[1].textContent).to.contain('help documentation');
+
+		});
+
+		it('should contain only tutorial specific text when only tutorial link specified', async() => {
+			innerFlyout.helpDocsLink = null;
+			await innerFlyout.updateComplete;
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(1);
+
+			expect(links[0].href).to.contain('https://www.testlink1.com');
+			expect(links[0].textContent).to.contain('tutorials');
+
+		});
+
+		it('should contain only help documentation specific text when only help link specified', async() => {
+			innerFlyout.tutorialLink = null;
+			await innerFlyout.updateComplete;
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(1);
+
+			expect(links[0].href).to.contain('https://www.testlink2.com');
+			expect(links[0].textContent).to.contain('help documentation');
+		});
+
+		it('should contain enable button', () => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
+			expect(button.textContent).to.equal('Turn it on');
+			expect(button).to.exist;
+		});
+
+		it('should contain leave it off button', () => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button:not([primary])');
+			expect(button.textContent).to.equal('Leave it off');
+			expect(button).to.exist;
+		});
+
+		it('should fire opt-in event when enable button clicked', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
+			clickElem(button);
+			await oneEvent(flyout, 'opt-in');
+		});
+
+		it('should fire flyout-closed event when enable button clicked', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
+			clickElem(button);
+			await oneEvent(flyout, 'flyout-closed');
+		});
+
+		it('should fire opt-out event when leave it disabled button clicked', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button:not([primary])');
+			clickElem(button);
+			await oneEvent(flyout, 'opt-out');
+		});
+
+		it('should fire flyout-closed event when leave it disabled button clicked', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button:not([primary])');
+			clickElem(button);
+			await oneEvent(flyout, 'flyout-closed');
+		});
+
+		it('should fire flyout-closed event when tab clicked', async() => {
+			const tab = innerFlyout.shadowRoot.querySelector('.flyout-tab');
+			clickElem(tab);
+			await oneEvent(flyout, 'flyout-closed');
+		});
+
+	});
+
+	describe('flyout closed', () => {
+
+		let flyout, innerFlyout;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`<d2l-opt-in-flyout></d2l-opt-in-flyout>`);
+			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+		});
+
+		it('should fire flyout-opened event when tab clicked', async() => {
+			const tab = innerFlyout.shadowRoot.querySelector('.flyout-tab');
+			clickElem(tab);
+			await oneEvent(flyout, 'flyout-opened');
+		});
+
+	});
+
+});

--- a/test/components/opt-in-flyout/opt-out-dialog.test.js
+++ b/test/components/opt-in-flyout/opt-out-dialog.test.js
@@ -1,0 +1,133 @@
+import '../../../src/components/opt-in-flyout/opt-out-dialog.js';
+import '../../../src/components/opt-in-flyout/opt-out-reason.js';
+import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+
+const setSelection = (reasonSelector, selectIndex) => {
+	const select = reasonSelector.shadowRoot.querySelector('select');
+	select.selectedIndex = selectIndex;
+	reasonSelector._reasonSelected();
+};
+
+const setFeedback = (flyout, value) => {
+	const feedback = flyout.shadowRoot.querySelector('d2l-input-textarea');
+	feedback.value = value;
+};
+
+const clickDone = (flyout) => {
+	const doneButton = flyout.shadowRoot.querySelector('d2l-button[primary]');
+	clickElem(doneButton);
+};
+
+describe('opt-out-dialog', () => {
+
+	describe('defaults', () => {
+
+		let flyout, reasonSelector;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`<d2l-opt-out-dialog></d2l-opt-out-dialog>`);
+			reasonSelector = flyout.shadowRoot.querySelector('opt-out-reason-selector');
+		});
+
+		it('should contain a title', () => {
+			const message = flyout.shadowRoot.querySelector('#title-label');
+			expect(message.textContent).to.contain('Let us know how to improve!');
+		});
+
+		it('should contain opt-out-reason-selector', () => {
+			const selector = flyout.shadowRoot.querySelector('opt-out-reason-selector');
+			expect(selector).to.exist;
+		});
+
+		it('should contain feedback text input box', () => {
+			const feedback = flyout.shadowRoot.querySelector('#feedback');
+			expect(feedback).to.exist;
+		});
+
+		it('should contain cancel button', () => {
+			const cancelButton = flyout.shadowRoot.querySelector('d2l-button:not([primary])');
+			expect(cancelButton).to.exist;
+		});
+
+		it('should fire confirm event when reason selected and done clicked (no feedback)', async() => {
+			setSelection(reasonSelector, 1);
+			clickDone(flyout);
+			const e = await oneEvent(flyout, 'confirm');
+			expect(e.detail.reason).to.equal('PreferOldExperience');
+			expect(e.detail.feedback).to.equal('');
+		});
+
+		it('should fire confirm event when reason selected and done clicked with feedback', async() => {
+			const textFeedback = 'not a fan';
+			setSelection(reasonSelector, 1);
+			setFeedback(flyout, textFeedback);
+			clickDone(flyout);
+			const e = await oneEvent(flyout, 'confirm');
+			expect(e.detail.reason).to.equal('PreferOldExperience');
+			expect(e.detail.feedback).to.equal(textFeedback);
+		});
+
+	});
+
+	describe('options specified', () => {
+
+		let flyout, reasonSelector;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`
+				<d2l-opt-out-dialog>
+					<d2l-opt-out-reason key="test-1" text="Test Option 1"></d2l-opt-out-reason>
+					<d2l-opt-out-reason key="test-2" text="Test Option 2"></d2l-opt-out-reason>
+				</d2l-opt-out-dialog>
+			`);
+			reasonSelector = flyout.shadowRoot.querySelector('opt-out-reason-selector');
+		});
+
+		it('should contain the first option', async() => {
+			setSelection(reasonSelector, 1);
+			clickDone(flyout);
+			const e = await oneEvent(flyout, 'confirm');
+			expect(e.detail.reason).to.equal('test-1');
+		});
+
+		it('should contain the second option', async() => {
+			setSelection(reasonSelector, 2);
+			clickDone(flyout);
+			const e = await oneEvent(flyout, 'confirm');
+			expect(e.detail.reason).to.equal('test-2');
+		});
+
+	});
+
+	describe('reason hidden', () => {
+
+		it('fires confirm with no reason', async() => {
+			const flyout = await fixture(html`
+				<d2l-opt-out-dialog hide-reason>
+					<d2l-opt-out-reason key="test-1" text="Test Option 1"></d2l-opt-out-reason>
+					<d2l-opt-out-reason key="test-2" text="Test Option 2"></d2l-opt-out-reason>
+				</d2l-opt-out-dialog>
+			`);
+			const hiddenReason = flyout.shadowRoot.querySelector('div[hidden] > #reason-selector');
+			expect(hiddenReason).to.exist;
+			clickDone(flyout);
+			const e = await oneEvent(flyout, 'confirm');
+			expect(e.detail.reason).to.equal('');
+		});
+
+	});
+
+	describe('feedback hidden', () => {
+
+		it('fires confirm with no feedback', async() => {
+			const flyout = await fixture(html`<d2l-opt-out-dialog hide-feedback></d2l-opt-out-dialog>`);
+			const hiddenFeedback = flyout.shadowRoot.querySelector('div[hidden] > #feedback');
+			expect(hiddenFeedback).to.exist;
+			clickDone(flyout);
+			const e = await oneEvent(flyout, 'confirm');
+			expect(e.detail.feedback).to.equal('');
+		});
+
+	});
+
+});

--- a/test/components/opt-in-flyout/opt-out-dialog.test.js
+++ b/test/components/opt-in-flyout/opt-out-dialog.test.js
@@ -25,8 +25,8 @@ describe('opt-out-dialog', () => {
 		let flyout, reasonSelector;
 
 		beforeEach(async() => {
-			flyout = await fixture(html`<d2l-opt-out-dialog></d2l-opt-out-dialog>`);
-			reasonSelector = flyout.shadowRoot.querySelector('opt-out-reason-selector');
+			flyout = await fixture(html`<d2l-labs-opt-out-dialog></d2l-labs-opt-out-dialog>`);
+			reasonSelector = flyout.shadowRoot.querySelector('d2l-labs-opt-out-reason-selector');
 		});
 
 		it('should contain a title', () => {
@@ -34,8 +34,8 @@ describe('opt-out-dialog', () => {
 			expect(message.textContent).to.contain('Let us know how to improve!');
 		});
 
-		it('should contain opt-out-reason-selector', () => {
-			const selector = flyout.shadowRoot.querySelector('opt-out-reason-selector');
+		it('should contain d2l-labs-opt-out-reason-selector', () => {
+			const selector = flyout.shadowRoot.querySelector('d2l-labs-opt-out-reason-selector');
 			expect(selector).to.exist;
 		});
 
@@ -75,12 +75,12 @@ describe('opt-out-dialog', () => {
 
 		beforeEach(async() => {
 			flyout = await fixture(html`
-				<d2l-opt-out-dialog>
-					<d2l-opt-out-reason key="test-1" text="Test Option 1"></d2l-opt-out-reason>
-					<d2l-opt-out-reason key="test-2" text="Test Option 2"></d2l-opt-out-reason>
-				</d2l-opt-out-dialog>
+				<d2l-labs-opt-out-dialog>
+					<d2l-labs-opt-out-reason key="test-1" text="Test Option 1"></d2l-labs-opt-out-reason>
+					<d2l-labs-opt-out-reason key="test-2" text="Test Option 2"></d2l-labs-opt-out-reason>
+				</d2l-labs-opt-out-dialog>
 			`);
-			reasonSelector = flyout.shadowRoot.querySelector('opt-out-reason-selector');
+			reasonSelector = flyout.shadowRoot.querySelector('d2l-labs-opt-out-reason-selector');
 		});
 
 		it('should contain the first option', async() => {
@@ -103,10 +103,10 @@ describe('opt-out-dialog', () => {
 
 		it('fires confirm with no reason', async() => {
 			const flyout = await fixture(html`
-				<d2l-opt-out-dialog hide-reason>
-					<d2l-opt-out-reason key="test-1" text="Test Option 1"></d2l-opt-out-reason>
-					<d2l-opt-out-reason key="test-2" text="Test Option 2"></d2l-opt-out-reason>
-				</d2l-opt-out-dialog>
+				<d2l-labs-opt-out-dialog hide-reason>
+					<d2l-labs-opt-out-reason key="test-1" text="Test Option 1"></d2l-labs-opt-out-reason>
+					<d2l-labs-opt-out-reason key="test-2" text="Test Option 2"></d2l-labs-opt-out-reason>
+				</d2l-labs-opt-out-dialog>
 			`);
 			const hiddenReason = flyout.shadowRoot.querySelector('div[hidden] > #reason-selector');
 			expect(hiddenReason).to.exist;
@@ -120,7 +120,7 @@ describe('opt-out-dialog', () => {
 	describe('feedback hidden', () => {
 
 		it('fires confirm with no feedback', async() => {
-			const flyout = await fixture(html`<d2l-opt-out-dialog hide-feedback></d2l-opt-out-dialog>`);
+			const flyout = await fixture(html`<d2l-labs-opt-out-dialog hide-feedback></d2l-labs-opt-out-dialog>`);
 			const hiddenFeedback = flyout.shadowRoot.querySelector('div[hidden] > #feedback');
 			expect(hiddenFeedback).to.exist;
 			clickDone(flyout);

--- a/test/components/opt-in-flyout/opt-out-flyout.test.js
+++ b/test/components/opt-in-flyout/opt-out-flyout.test.js
@@ -1,0 +1,178 @@
+import '../../../src/components/opt-in-flyout/opt-out-flyout.js';
+import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import TestUtil from './utilities.js';
+
+describe('d2l-opt-out-flyout', () => {
+
+	describe('defaults', () => {
+
+		let flyout, innerFlyout;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`<d2l-opt-out-flyout open></d2l-opt-out-flyout>`);
+			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+		});
+
+		it('should not contain short description', () => {
+			const shortDescription = innerFlyout.shadowRoot.querySelector('#short-description');
+			expect(shortDescription).to.not.exist;
+		});
+
+		it('should not contain long description', () => {
+			const longDescription = innerFlyout.shadowRoot.querySelector('#long-description');
+			expect(longDescription).to.not.exist;
+		});
+
+		it('should not contain tutorial link or help documentation if not set', () => {
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			expect(tutorial).to.not.exist;
+		});
+
+		it('should not display reason dialog', () => {
+			const dialog = innerFlyout.shadowRoot.querySelector('d2l-opt-out-dialog');
+			expect(dialog).to.equal(null);
+		});
+
+	});
+
+	describe('properties specified', () => {
+
+		let flyout, innerFlyout;
+
+		beforeEach(async() => {
+			flyout = await fixture(html`
+				<d2l-opt-out-flyout
+					open
+					title="Flyout Demo"
+					short-description="This is a short description"
+					long-description="This is a long description"
+					tab-position="right"
+					tutorial-link="https://www.testlink1.com"
+					help-docs-link="https://www.testlink2.com"></d2l-opt-out-flyout>
+			`);
+			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+		});
+
+		it('should contain short description', () => {
+			const shortDescription = innerFlyout.shadowRoot.querySelector('#short-description');
+			expect(shortDescription).to.exist;
+		});
+
+		it('should contain title', () => {
+			const title = innerFlyout.shadowRoot.querySelector('#title');
+			expect(title.textContent).to.equal('Flyout Demo');
+		});
+
+		it('should reflect title attribute to property', async() => {
+			const newTitle = 'new title';
+			flyout.setAttribute('title', newTitle);
+			await flyout.updateComplete;
+			await innerFlyout.updateComplete;
+			expect(flyout.title).to.equal(newTitle);
+			const title = innerFlyout.shadowRoot.querySelector('#title');
+			expect(title.textContent).to.equal(newTitle);
+		});
+
+		it('should contain long description', () => {
+			const longDescription = innerFlyout.shadowRoot.querySelector('#long-description');
+			expect(longDescription).to.exist;
+		});
+
+		it('should contain tutorial link', () => {
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(2);
+
+			expect(links[0].href).to.contain('https://www.testlink1.com');
+			expect(links[0].textContent).to.contain('tutorials');
+		});
+
+		it('should contain help documentation link', () => {
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(2);
+
+			expect(links[1].href).to.contain('https://www.testlink2.com');
+			expect(links[1].textContent).to.contain('help documentation');
+		});
+
+		it('should contain only tutorial specific text when only tutorial link specified', async() => {
+			innerFlyout.helpDocsLink = null;
+			await innerFlyout.updateComplete;
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(1);
+
+			expect(links[0].href).to.contain('https://www.testlink1.com');
+			expect(links[0].textContent).to.contain('tutorials');
+		});
+
+		it('should contain only help documentation specific text when only help link specified', async() => {
+			innerFlyout.tutorialLink = null;
+			await innerFlyout.updateComplete;
+			const tutorial = innerFlyout.shadowRoot.querySelector('.flyout-tutorial');
+			const links = TestUtil.selectVisible(tutorial, 'a');
+
+			expect(links.length).to.equal(1);
+
+			expect(links[0].href).to.contain('https://www.testlink2.com');
+			expect(links[0].textContent).to.contain('help documentation');
+		});
+
+		it('should contain enable button', () => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
+			expect(button.textContent).to.equal('Leave it on');
+			expect(button).to.exist;
+		});
+
+		it('should contain turn it off button', () => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button:not([primary])');
+			expect(button.textContent).to.equal('Turn it off');
+			expect(button).to.exist;
+		});
+
+		it('should fire opt-in event when "leave it on" button clicked', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
+			clickElem(button);
+			await oneEvent(flyout, 'opt-in');
+		});
+
+		it('should fire flyout-closed event when "leave it on" button clicked and not display dialog', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
+			clickElem(button);
+			await oneEvent(flyout, 'flyout-closed');
+			const dialog = innerFlyout.shadowRoot.querySelector('d2l-opt-out-dialog');
+			expect(dialog).to.not.exist;
+		});
+
+		it('should open reason dialog when "turn it off" button clicked', async() => {
+			const button = innerFlyout.shadowRoot.querySelector('d2l-button:not([primary])');
+			await clickElem(button);
+			const dialog = innerFlyout.shadowRoot.querySelector('d2l-opt-out-dialog');
+			expect(dialog).to.exist;
+		});
+
+		it('should fire flyout-closed event when tab clicked', async() => {
+			const tab = innerFlyout.shadowRoot.querySelector('.flyout-tab');
+			clickElem(tab);
+			await oneEvent(flyout, 'flyout-closed');
+		});
+
+	});
+
+	describe('flyout closed', () => {
+
+		it('should fire flyout-opened event when tab clicked', async() => {
+			const flyout = await fixture(html`<d2l-opt-out-flyout></d2l-opt-out-flyout>`);
+			const innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			const tab = innerFlyout.shadowRoot.querySelector('.flyout-tab');
+			clickElem(tab);
+			await oneEvent(flyout, 'flyout-opened');
+		});
+
+	});
+
+});

--- a/test/components/opt-in-flyout/opt-out-flyout.test.js
+++ b/test/components/opt-in-flyout/opt-out-flyout.test.js
@@ -2,15 +2,15 @@ import '../../../src/components/opt-in-flyout/opt-out-flyout.js';
 import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import TestUtil from './utilities.js';
 
-describe('d2l-opt-out-flyout', () => {
+describe('d2l-labs-opt-out-flyout', () => {
 
 	describe('defaults', () => {
 
 		let flyout, innerFlyout;
 
 		beforeEach(async() => {
-			flyout = await fixture(html`<d2l-opt-out-flyout open></d2l-opt-out-flyout>`);
-			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			flyout = await fixture(html`<d2l-labs-opt-out-flyout open></d2l-labs-opt-out-flyout>`);
+			innerFlyout = flyout.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 		});
 
 		it('should not contain short description', () => {
@@ -29,7 +29,7 @@ describe('d2l-opt-out-flyout', () => {
 		});
 
 		it('should not display reason dialog', () => {
-			const dialog = innerFlyout.shadowRoot.querySelector('d2l-opt-out-dialog');
+			const dialog = innerFlyout.shadowRoot.querySelector('d2l-labs-opt-out-dialog');
 			expect(dialog).to.equal(null);
 		});
 
@@ -41,16 +41,16 @@ describe('d2l-opt-out-flyout', () => {
 
 		beforeEach(async() => {
 			flyout = await fixture(html`
-				<d2l-opt-out-flyout
+				<d2l-labs-opt-out-flyout
 					open
 					title="Flyout Demo"
 					short-description="This is a short description"
 					long-description="This is a long description"
 					tab-position="right"
 					tutorial-link="https://www.testlink1.com"
-					help-docs-link="https://www.testlink2.com"></d2l-opt-out-flyout>
+					help-docs-link="https://www.testlink2.com"></d2l-labs-opt-out-flyout>
 			`);
-			innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			innerFlyout = flyout.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 		});
 
 		it('should contain short description', () => {
@@ -144,14 +144,14 @@ describe('d2l-opt-out-flyout', () => {
 			const button = innerFlyout.shadowRoot.querySelector('d2l-button[primary]');
 			clickElem(button);
 			await oneEvent(flyout, 'flyout-closed');
-			const dialog = innerFlyout.shadowRoot.querySelector('d2l-opt-out-dialog');
+			const dialog = innerFlyout.shadowRoot.querySelector('d2l-labs-opt-out-dialog');
 			expect(dialog).to.not.exist;
 		});
 
 		it('should open reason dialog when "turn it off" button clicked', async() => {
 			const button = innerFlyout.shadowRoot.querySelector('d2l-button:not([primary])');
 			await clickElem(button);
-			const dialog = innerFlyout.shadowRoot.querySelector('d2l-opt-out-dialog');
+			const dialog = innerFlyout.shadowRoot.querySelector('d2l-labs-opt-out-dialog');
 			expect(dialog).to.exist;
 		});
 
@@ -166,8 +166,8 @@ describe('d2l-opt-out-flyout', () => {
 	describe('flyout closed', () => {
 
 		it('should fire flyout-opened event when tab clicked', async() => {
-			const flyout = await fixture(html`<d2l-opt-out-flyout></d2l-opt-out-flyout>`);
-			const innerFlyout = flyout.shadowRoot.querySelector('flyout-impl');
+			const flyout = await fixture(html`<d2l-labs-opt-out-flyout></d2l-labs-opt-out-flyout>`);
+			const innerFlyout = flyout.shadowRoot.querySelector('d2l-labs-opt-in-flyout-impl');
 			const tab = innerFlyout.shadowRoot.querySelector('.flyout-tab');
 			clickElem(tab);
 			await oneEvent(flyout, 'flyout-opened');

--- a/test/components/opt-in-flyout/utilities.js
+++ b/test/components/opt-in-flyout/utilities.js
@@ -1,0 +1,21 @@
+const toArray = function(collection) {
+	if (Array.from) {
+		return Array.from(collection);
+	}
+
+	const array = [];
+	for (let i = 0; i < collection.length; i++) {
+		array.push(collection[i]);
+	}
+	return array;
+};
+
+export default {
+
+	selectVisible: function(element, querySelector) {
+		return toArray(element.querySelectorAll(querySelector)).filter(
+			node => node.offsetParent !== null
+		);
+	}
+
+};


### PR DESCRIPTION
This moves the opt-in-flyout from [its repo](https://github.com/BrightspaceUILabs/opt-in-flyout) into the Labs monorepo (here). Once BSI (the only consumer) is switched over, I'll Graveyard the other repo.

The old repo doesn't have vdiff tests, but after this part is in I'm going to add some. I think that will allow me to delete most of the "unit" tests, which are doing a lot of assertions about the presence/absence of particular elements.