### PR TITLE
fix: add a11y tests and fix select label

### DIFF
--- a/src/components/opt-in-flyout/opt-out-dialog.js
+++ b/src/components/opt-in-flyout/opt-out-dialog.js
@@ -114,8 +114,7 @@ class OptOutDialog extends composeMixins(
 				<label id="title-label">${this.localize('components:optInFlyout:feedbackTitle')}</label>
 				<br><br>
 				<div ?hidden="${this.hideReason}">
-					<label id="reason-label">${this.localize('components:optInFlyout:feedbackReasonLabel')}</label>
-					<d2l-labs-opt-out-reason-selector id="reason-selector" aria-labelledby="reason-label" @selected="${this._handleSelected}">
+					<d2l-labs-opt-out-reason-selector id="reason-selector" @selected="${this._handleSelected}">
 						<slot></slot>
 					</d2l-labs-opt-out-reason-selector>
 				</div>

--- a/src/components/opt-in-flyout/opt-out-reason-selector.js
+++ b/src/components/opt-in-flyout/opt-out-reason-selector.js
@@ -20,6 +20,11 @@ class OptOutReasonSelector extends composeMixins(
 		return [
 			inputStyles,
 			css`
+				label {
+					display: block;
+					margin-bottom: 0.5rem;
+				}
+
 				select {
 					-moz-appearance: none;
 					-webkit-appearance: none;
@@ -68,6 +73,7 @@ class OptOutReasonSelector extends composeMixins(
 
 	render() {
 		return html`
+			<label for="selector">${this.localize('components:optInFlyout:feedbackReasonLabel')}</label>
 			<select class="d2l-input" id="selector" @change="${this._reasonSelected}" onload="${this.focus()}">
 				<option disabled="" value="">${this.localize('components:optInFlyout:feedbackChooseReason')}</option>
 				${this._reasons.map((item) => html`<option value="${item.key}">${item.text}</option>`)}

--- a/test/components/opt-in-flyout/opt-in-flyout.test.js
+++ b/test/components/opt-in-flyout/opt-in-flyout.test.js
@@ -1,5 +1,5 @@
 import '../../../src/components/opt-in-flyout/flyout-impl.js';
-import { clickElem, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 const closedFixture = html`
 	<d2l-labs-opt-in-flyout-impl flyout-title="Opt-In Flyout">
@@ -27,6 +27,20 @@ async function clickOptOutButton(elem) {
 }
 
 describe('opt-in-flyout', () => {
+
+	describe('accessibility', () => {
+
+		it('closed', async() => {
+			const elem = await fixture(closedFixture);
+			await expect(elem).to.be.accessible();
+		});
+
+		it('opened', async() => {
+			const elem = await fixture(openedFixture);
+			await expect(elem).to.be.accessible();
+		});
+
+	});
 
 	describe('events', () => {
 

--- a/test/components/opt-in-flyout/opt-out-dialog.test.js
+++ b/test/components/opt-in-flyout/opt-out-dialog.test.js
@@ -21,13 +21,20 @@ const clickDone = (elem) => {
 
 describe('opt-out-dialog', () => {
 
-	describe('events', () => {
+	let elem;
+	beforeEach(async() => {
+		elem = await fixture(html`<d2l-labs-opt-out-dialog></d2l-labs-opt-out-dialog>`);
+	});
 
-		let elem;
+	describe('accessibility', () => {
 
-		beforeEach(async() => {
-			elem = await fixture(html`<d2l-labs-opt-out-dialog></d2l-labs-opt-out-dialog>`);
+		it('should be accessible', async() => {
+			await expect(elem).to.be.accessible();
 		});
+
+	});
+
+	describe('events', () => {
 
 		it('should dispatch "confirm" event when reason selected and done clicked (no feedback)', async() => {
 			setSelection(elem, 1);


### PR DESCRIPTION
If this is meant to act as an example, I figured I should add some accessibility tests. They found a missing label on a `<select>`. There's a bunch of other weird `<label>` stuff going on here, and they don't match our actual for label styles, but I think I'm going to draw the line here to limit visual changes.