### PR TITLE
Remove constructor-test-helper reference

### DIFF
--- a/test/components/checkbox-drawer/checkbox-drawer.test.js
+++ b/test/components/checkbox-drawer/checkbox-drawer.test.js
@@ -1,6 +1,5 @@
 import '../../../src/components/checkbox-drawer/checkbox-drawer.js';
-import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 function getInputCheckbox(component) {
 	return component.shadowRoot.querySelector('d2l-input-checkbox');

--- a/test/components/pagination/pager-numeric.test.js
+++ b/test/components/pagination/pager-numeric.test.js
@@ -1,7 +1,6 @@
 import '../../../src/components/pagination/pager-numeric.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 const custompageSizes = [2, 5, 37, 159];
 


### PR DESCRIPTION
This repo uses `@brightspace-ui/testing`, so it can just get `runConstructor` from there. Someday, we'll want to remove the one in `core`.