### PR TITLE
Split out axe tests for better tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,27 @@ jobs:
         run: npm run lint:style
       - name: Validate Translations
         run: npm run test:translations
-      - name: Unit Tests (cross-browser)
+      - name: Accessibility Tests
+        id: at
+        run: npm run test:axe
+      - name: Upload test report
+        if: >
+          always() &&
+          github.triggering_actor != 'dependabot[bot]' &&
+          (steps.at.outcome == 'failure' || steps.at.outcome == 'success')
+        uses: Brightspace/test-reporting-action@main
+        with:
+          aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}
+          aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          aws-session-token: ${{secrets.AWS_SESSION_TOKEN}}
+      - name: Unit Tests
+        id: ut
         run: npm run test:unit
       - name: Upload test report
-        if: github.triggering_actor != 'dependabot[bot]' && (failure() || success())
+        if: >
+          always() &&
+          github.triggering_actor != 'dependabot[bot]' &&
+          (steps.ut.outcome == 'failure' || steps.ut.outcome == 'success')
         uses: Brightspace/test-reporting-action@main
         with:
           aws-access-key-id: ${{secrets.AWS_ACCESS_KEY_ID}}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ npm run lint:style
 # translations
 npm run test:translations
 
+# accessibility tests
+npm run test:axe
+
 # unit tests
 npm run test:unit
 ```

--- a/d2l-test-reporting.config.json
+++ b/d2l-test-reporting.config.json
@@ -7,6 +7,10 @@
       "type": "UI Unit"
     },
     {
+      "pattern": "test/**/*.axe.js",
+      "type": "UI Accessibility"
+    },
+    {
       "pattern": "test/**/*.vdiff.js",
       "type": "UI Visual Diff"
     }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --node-resolve --open --watch",
-    "test": "npm run lint && npm run test:translations && npm run test:unit",
+    "test": "npm run lint && npm run test:translations && npm run test:unit && npm run test:axe",
     "test:translations": "mfv -e -i untranslated",
+    "test:axe": "d2l-test-runner axe --chrome",
     "test:unit": "d2l-test-runner",
     "test:vdiff": "d2l-test-runner vdiff"
   },

--- a/test/components/checkbox-drawer/checkbox-drawer.axe.js
+++ b/test/components/checkbox-drawer/checkbox-drawer.axe.js
@@ -1,0 +1,15 @@
+import '../../../src/components/checkbox-drawer/checkbox-drawer.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+
+describe('checkbox-drawer', () => {
+
+	describe('accessibility', () => {
+		[false, true].forEach(checked => {
+			it(`should pass all aXe tests (${!checked ? 'un' : ''}checked)`, async() => {
+				const el = await fixture(html`<d2l-labs-checkbox-drawer label="Label" ?checked=${checked}></d2l-labs-checkbox-drawer>`);
+				await expect(el).to.be.accessible();
+			});
+		});
+	});
+
+});

--- a/test/components/checkbox-drawer/checkbox-drawer.test.js
+++ b/test/components/checkbox-drawer/checkbox-drawer.test.js
@@ -13,15 +13,6 @@ describe('checkbox-drawer', () => {
 		});
 	});
 
-	describe('accessibility', () => {
-		[false, true].forEach(checked => {
-			it(`should pass all aXe tests (${!checked ? 'un' : ''}checked)`, async() => {
-				const el = await fixture(html`<d2l-labs-checkbox-drawer label="Label" ?checked=${checked}></d2l-labs-checkbox-drawer>`);
-				await expect(el).to.be.accessible();
-			});
-		});
-	});
-
 	describe('events', () => {
 		[ false, true ].forEach(checked => {
 			const action = checked ? 'collapse' : 'expand';

--- a/test/components/opt-in-flyout/opt-in-flyout.axe.js
+++ b/test/components/opt-in-flyout/opt-in-flyout.axe.js
@@ -1,0 +1,30 @@
+import '../../../src/components/opt-in-flyout/flyout-impl.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+
+const closedFixture = html`
+	<d2l-labs-opt-in-flyout-impl flyout-title="Opt-In Flyout">
+	</d2l-labs-opt-in-flyout-impl>
+`;
+
+const openedFixture = html`
+	<d2l-labs-opt-in-flyout-impl flyout-title="Opt-In Flyout" opened>
+	</d2l-labs-opt-in-flyout-impl>
+`;
+
+describe('opt-in-flyout', () => {
+
+	describe('accessibility', () => {
+
+		it('closed', async() => {
+			const elem = await fixture(closedFixture);
+			await expect(elem).to.be.accessible();
+		});
+
+		it('opened', async() => {
+			const elem = await fixture(openedFixture);
+			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+});

--- a/test/components/opt-in-flyout/opt-in-flyout.test.js
+++ b/test/components/opt-in-flyout/opt-in-flyout.test.js
@@ -1,5 +1,5 @@
 import '../../../src/components/opt-in-flyout/flyout-impl.js';
-import { clickElem, expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { clickElem, fixture, html, oneEvent } from '@brightspace-ui/testing';
 
 const closedFixture = html`
 	<d2l-labs-opt-in-flyout-impl flyout-title="Opt-In Flyout">
@@ -27,20 +27,6 @@ async function clickOptOutButton(elem) {
 }
 
 describe('opt-in-flyout', () => {
-
-	describe('accessibility', () => {
-
-		it('closed', async() => {
-			const elem = await fixture(closedFixture);
-			await expect(elem).to.be.accessible();
-		});
-
-		it('opened', async() => {
-			const elem = await fixture(openedFixture);
-			await expect(elem).to.be.accessible();
-		});
-
-	});
 
 	describe('events', () => {
 

--- a/test/components/opt-in-flyout/opt-out-dialog.axe.js
+++ b/test/components/opt-in-flyout/opt-out-dialog.axe.js
@@ -1,0 +1,20 @@
+import '../../../src/components/opt-in-flyout/opt-out-dialog.js';
+import '../../../src/components/opt-in-flyout/opt-out-reason.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+
+describe('opt-out-dialog', () => {
+
+	let elem;
+	beforeEach(async() => {
+		elem = await fixture(html`<d2l-labs-opt-out-dialog></d2l-labs-opt-out-dialog>`);
+	});
+
+	describe('accessibility', () => {
+
+		it('should be accessible', async() => {
+			await expect(elem).to.be.accessible();
+		});
+
+	});
+
+});

--- a/test/components/opt-in-flyout/opt-out-dialog.test.js
+++ b/test/components/opt-in-flyout/opt-out-dialog.test.js
@@ -26,14 +26,6 @@ describe('opt-out-dialog', () => {
 		elem = await fixture(html`<d2l-labs-opt-out-dialog></d2l-labs-opt-out-dialog>`);
 	});
 
-	describe('accessibility', () => {
-
-		it('should be accessible', async() => {
-			await expect(elem).to.be.accessible();
-		});
-
-	});
-
 	describe('events', () => {
 
 		it('should dispatch "confirm" event when reason selected and done clicked (no feedback)', async() => {

--- a/test/components/pagination/pager-numeric.axe.js
+++ b/test/components/pagination/pager-numeric.axe.js
@@ -1,0 +1,29 @@
+import '../../../src/components/pagination/pager-numeric.js';
+import { expect, fixture, html } from '@brightspace-ui/testing';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+const custompageSizes = [2, 5, 37, 159];
+
+async function createComponent({ pageNumber, maxPageNumber, showPageSizeSelector = false, pageSizes, pageSize } = {}) {
+	return await fixture(html`<d2l-labs-pager-numeric
+		page-number="${ifDefined(pageNumber)}"
+		max-page-number="${ifDefined(maxPageNumber)}"
+		?show-page-size-selector="${showPageSizeSelector}"
+		.pageSizes="${pageSizes}"
+		page-size="${ifDefined(pageSize)}">
+	</d2l-labs-pager-numeric>`);
+}
+
+describe('pager-numeric', () => {
+	describe('accessibility', () => {
+		it('should pass all axe tests (basic)', async() => {
+			const component = await createComponent();
+			await expect(component).to.be.accessible();
+		});
+
+		it('should pass all axe tests (full)', async() => {
+			const component = await createComponent({ pageNumber: 1, maxPageNumber: 6, showPageSizeSelector: true, pageSizes: custompageSizes, pageSize: 20 });
+			await expect(component).to.be.accessible();
+		});
+	});
+});

--- a/test/components/pagination/pager-numeric.test.js
+++ b/test/components/pagination/pager-numeric.test.js
@@ -21,18 +21,6 @@ describe('pager-numeric', () => {
 		});
 	});
 
-	describe('accessibility', () => {
-		it('should pass all axe tests (basic)', async() => {
-			const component = await createComponent();
-			await expect(component).to.be.accessible();
-		});
-
-		it('should pass all axe tests (full)', async() => {
-			const component = await createComponent({ pageNumber: 1, maxPageNumber: 6, showPageSizeSelector: true, pageSizes: custompageSizes, pageSize: 20 });
-			await expect(component).to.be.accessible();
-		});
-	});
-
 	describe('render', () => {
 		// This couldn't get turned into a vdiff test due to complications with the 'select' component
 		it('should render page size selector with correct options and initial selection', async() => {


### PR DESCRIPTION
I'm hoping eventually to find a better way to do this so we can track at the test level but based on the current test reporting implementation this is the easiest way to track them separately from just standard old unit tests.