### PR TITLE
Update to latest `@brightspace-ui/testing`

### DIFF
--- a/d2l-test-runner.config.js
+++ b/d2l-test-runner.config.js
@@ -1,5 +1,0 @@
-import { env } from 'node:process';
-
-export default {
-	testReporting: !!env['CI']
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -405,9 +405,9 @@
       }
     },
     "node_modules/@brightspace-ui/testing": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-1.18.0.tgz",
-      "integrity": "sha512-Bm02WQiHUxQEP1Krc59ibNXBexvClG+lpWjBmkHFUxJc+mYfA59pTasAgV3FBTh/qEAvOCC4Cqj4GJHFYbSRCQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/testing/-/testing-1.20.0.tgz",
+      "integrity": "sha512-SbwjG9I+Kc2BVpNDUCgNnHvZW2WimexzM4U38QfrnNaNlGROm2sx7+SuMGE+wtuTvXnwdnZFEnwXuoIMzqGWWA==",
       "dev": true,
       "dependencies": {
         "@brightspace-ui/intl": "^3",


### PR DESCRIPTION
The default is to generate the report in CI now.