### PR TITLE
feat: Switch to using proxies for reactive store consumers

### DIFF
--- a/demo/utilities/reactive-store/basic-demo.js
+++ b/demo/utilities/reactive-store/basic-demo.js
@@ -15,19 +15,23 @@ class BasicDemo extends LitElement {
 
 	render() {
 		return html`
-			<div>Foo: ${this.consumer.foo}</div>
-			<div>Bar: ${this.consumer.bar}</div>
-			<button @click=${this._updateFoo}>Update foo</button>
-			<button @click=${this._updateBar}>Update bar</button>
+			<div>Count: ${this.consumer.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 		`;
 	}
 
-	_updateBar() {
-		this.consumer.bar += 1;
+	_decrement() {
+		this.consumer.decrement();
 	}
 
-	_updateFoo() {
-		this.consumer.foo += 1;
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 

--- a/demo/utilities/reactive-store/context-demo.js
+++ b/demo/utilities/reactive-store/context-demo.js
@@ -14,19 +14,29 @@ class ContextDemo extends LitElement {
 
 		this.store = new MyStoreContextProvider(this);
 	}
+
 	render() {
 		return html`
 			<h2>Parent</h2>
-			<div>Foo: ${this.store.foo}</div>
-			<div>Bar: ${this.store.bar}</div>
-			<button @click=${this._click}>Update foo</button>
+			<div>Count: ${this.store.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 
 			<context-demo-child></context-demo-child>
 		`;
 	}
 
-	_click() {
-		this.store.foo += 1;
+	_decrement() {
+		this.store.decrement();
+	}
+
+	_increment() {
+		this.store.increment();
+	}
+
+	_reset() {
+		this.store.count = 0;
 	}
 }
 
@@ -36,16 +46,27 @@ class ContextDemoChild extends LitElement {
 
 		this.consumer = new MyStoreContextConsumer(this);
 	}
+
 	render() {
 		return html`
 			<h2>Child</h2>
-			<div>Foo: ${this.consumer.foo}</div>
-			<div>Bar: ${this.consumer.bar}</div>
-			<button @click=${this._click}>Update bar</button>
+			<div>Count: ${this.consumer.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 		`;
 	}
-	_click() {
-		this.consumer.bar += 1;
+
+	_decrement() {
+		this.consumer.decrement();
+	}
+
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 

--- a/demo/utilities/reactive-store/index.html
+++ b/demo/utilities/reactive-store/index.html
@@ -28,16 +28,22 @@
 export default class MyStore extends ReactiveStore {
 	static get properties() {
 		return {
-			foo: { type: Number },
-			bar: { type: Number },
+			count: { type: Number },
 		};
 	}
 
 	constructor() {
 		super();
 
-		this.foo = 0;
-		this.bar = 0;
+		this.count = 0;
+	}
+
+	decrement() {
+		this.count--;
+	}
+
+	increment() {
+		this.count++;
 	}
 }</d2l-code-view>
 			</d2l-collapsible-panel>
@@ -62,19 +68,23 @@ class BasicDemo extends LitElement {
 
 	render() {
 		return html`
-			&lt;div&gt;Foo: ${this.consumer.foo}&lt;/div&gt;
-			&lt;div&gt;Bar: ${this.consumer.bar}&lt;/div&gt;
-			&lt;button @click=${this._updateFoo}&gt;Update foo&lt;/button&gt;
-			&lt;button @click=${this._updateBar}&gt;Update bar&lt;/button&gt;
+			&lt;div&gt;Count: ${this.consumer.count}&lt;/div&gt;
+			&lt;button @click=${this._increment}&gt;Increment&lt;/button&gt;
+			&lt;button @click=${this._decrement}&gt;Decrement&lt;/button&gt;
+			&lt;button @click=${this._reset}&gt;Reset&lt;/button&gt;
 		`;
 	}
 
-	_updateBar() {
-		this.consumer.bar += 1;
+	_decrement() {
+		this.consumer.decrement();
 	}
 
-	_updateFoo() {
-		this.consumer.foo += 1;
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 
@@ -105,16 +115,25 @@ class MultipleConsumersDemo extends LitElement {
 	render() {
 		return html`
 			&lt;h2&gt;Parent&lt;/h2&gt;
-			&lt;div&gt;Foo: ${this.consumer.foo}&lt;/div&gt;
-			&lt;div&gt;Bar: ${this.consumer.bar}&lt;/div&gt;
-			&lt;button @click=${this._click}&gt;Update foo&lt;/button&gt;
+			&lt;div&gt;Count: ${this.consumer.count}&lt;/div&gt;
+			&lt;button @click=${this._increment}&gt;Increment&lt;/button&gt;
+			&lt;button @click=${this._decrement}&gt;Decrement&lt;/button&gt;
+			&lt;button @click=${this._reset}&gt;Reset&lt;/button&gt;
 
 			&lt;multiple-consumers-demo-child&gt;&lt;/multiple-consumers-demo-child&gt;
 		`;
 	}
 
-	_click() {
-		this.consumer.foo += 1;
+	_decrement() {
+		this.consumer.decrement();
+	}
+
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 
@@ -124,16 +143,27 @@ class MultipleConsumersDemoChild extends LitElement {
 
 		this.consumer = new MyStoreConsumer(this);
 	}
+
 	render() {
 		return html`
 			&lt;h2&gt;Child&lt;/h2&gt;
-			&lt;div&gt;Foo: ${this.consumer.foo}&lt;/div&gt;
-			&lt;div&gt;Bar: ${this.consumer.bar}&lt;/div&gt;
-			&lt;button @click=${this._click}&gt;Update bar&lt;/button&gt;
+			&lt;div&gt;Count: ${this.consumer.count}&lt;/div&gt;
+			&lt;button @click=${this._increment}&gt;Increment&lt;/button&gt;
+			&lt;button @click=${this._decrement}&gt;Decrement&lt;/button&gt;
+			&lt;button @click=${this._reset}&gt;Reset&lt;/button&gt;
 		`;
 	}
-	_click() {
-		this.consumer.bar += 1;
+
+	_decrement() {
+		this.consumer.decrement();
+	}
+
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 
@@ -163,19 +193,29 @@ class ContextDemo extends LitElement {
 
 		this.store = new MyStoreContextProvider(this);
 	}
+
 	render() {
 		return html`
 			&lt;h2&gt;Parent&lt;/h2&gt;
-			&lt;div&gt;Foo: ${this.store.foo}&lt;/div&gt;
-			&lt;div&gt;Bar: ${this.store.bar}&lt;/div&gt;
-			&lt;button @click=${this._click}&gt;Update foo&lt;/button&gt;
+			&lt;div&gt;Count: ${this.store.count}&lt;/div&gt;
+			&lt;button @click=${this._increment}&gt;Increment&lt;/button&gt;
+			&lt;button @click=${this._decrement}&gt;Decrement&lt;/button&gt;
+			&lt;button @click=${this._reset}&gt;Reset&lt;/button&gt;
 
 			&lt;context-demo-child&gt;&lt;/context-demo-child&gt;
 		`;
 	}
 
-	_click() {
-		this.store.foo += 1;
+	_decrement() {
+		this.store.decrement();
+	}
+
+	_increment() {
+		this.store.increment();
+	}
+
+	_reset() {
+		this.store.count = 0;
 	}
 }
 
@@ -185,16 +225,27 @@ class ContextDemoChild extends LitElement {
 
 		this.consumer = new MyStoreContextConsumer(this);
 	}
+
 	render() {
 		return html`
 			&lt;h2&gt;Child&lt;/h2&gt;
-			&lt;div&gt;Foo: ${this.consumer.foo}&lt;/div&gt;
-			&lt;div&gt;Bar: ${this.consumer.bar}&lt;/div&gt;
-			&lt;button @click=${this._click}&gt;Update bar&lt;/button&gt;
+			&lt;div&gt;Count: ${this.consumer.count}&lt;/div&gt;
+			&lt;button @click=${this._increment}&gt;Increment&lt;/button&gt;
+			&lt;button @click=${this._decrement}&gt;Decrement&lt;/button&gt;
+			&lt;button @click=${this._reset}&gt;Reset&lt;/button&gt;
 		`;
 	}
-	_click() {
-		this.consumer.bar += 1;
+
+	_decrement() {
+		this.consumer.decrement();
+	}
+
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 

--- a/demo/utilities/reactive-store/multiple-consumers-demo.js
+++ b/demo/utilities/reactive-store/multiple-consumers-demo.js
@@ -16,16 +16,25 @@ class MultipleConsumersDemo extends LitElement {
 	render() {
 		return html`
 			<h2>Parent</h2>
-			<div>Foo: ${this.consumer.foo}</div>
-			<div>Bar: ${this.consumer.bar}</div>
-			<button @click=${this._click}>Update foo</button>
+			<div>Count: ${this.consumer.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 
 			<multiple-consumers-demo-child></multiple-consumers-demo-child>
 		`;
 	}
 
-	_click() {
-		this.consumer.foo += 1;
+	_decrement() {
+		this.consumer.decrement();
+	}
+
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 
@@ -35,16 +44,27 @@ class MultipleConsumersDemoChild extends LitElement {
 
 		this.consumer = new MyStoreConsumer(this);
 	}
+
 	render() {
 		return html`
 			<h2>Child</h2>
-			<div>Foo: ${this.consumer.foo}</div>
-			<div>Bar: ${this.consumer.bar}</div>
-			<button @click=${this._click}>Update bar</button>
+			<div>Count: ${this.consumer.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 		`;
 	}
-	_click() {
-		this.consumer.bar += 1;
+
+	_decrement() {
+		this.consumer.decrement();
+	}
+
+	_increment() {
+		this.consumer.increment();
+	}
+
+	_reset() {
+		this.consumer.count = 0;
 	}
 }
 

--- a/demo/utilities/reactive-store/my-store.js
+++ b/demo/utilities/reactive-store/my-store.js
@@ -3,15 +3,21 @@ import ReactiveStore from '../../../src/utilities/reactive-store/reactive-store.
 export default class MyStore extends ReactiveStore {
 	static get properties() {
 		return {
-			foo: { type: Number },
-			bar: { type: Number },
+			count: { type: Number },
 		};
 	}
 
 	constructor() {
 		super();
 
-		this.foo = 0;
-		this.bar = 0;
+		this.count = 0;
+	}
+
+	decrement() {
+		this.count--;
+	}
+
+	increment() {
+		this.count++;
 	}
 }

--- a/src/utilities/reactive-store/README.md
+++ b/src/utilities/reactive-store/README.md
@@ -19,14 +19,22 @@ import ReactiveStore from '@brightspace-ui/labs/utilites/reactive-store.js';
 class MyStore extends ReactiveStore {
 	static get properties() {
 		return {
-			foo: { type: Number },
+			count: { type: Number },
 		};
 	}
 
 	constructor() {
 		super();
 
-		this.foo = 0;
+		this.count = 0;
+	}
+
+	increment() {
+		this.count++;
+	}
+
+	decrement() {
+		this.count--;
 	}
 }
 
@@ -56,15 +64,27 @@ class MyComponent extends LitElement {
 	render() {
 		// The consumer will have all the same properties defined in your store.
 		return html`
-			<div>Foo: ${this.myStoreConsumer.foo}</div>
-			<button @click=${this._click}>Update foo</button>
+			<div>Count: ${this.myStoreConsumer.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 		`;
 	}
 
-	_click() {
+	_reset() {
 		// Updating the values from the consumer will update the store, which will then
 		// notify all consumers of the changes and trigger component updates.
-		this.myStoreConsumer.foo += 1;
+		this.myStoreConsumer.count = 0;
+	}
+
+	_increment() {
+		// You can access any method or property defined in the store, not just reactive properties.
+		this.myStoreConsumer.increment();
+	}
+
+	_decrement() {
+		// You can access any method or property defined in the store, not just reactive properties.
+		this.myStoreConsumer.decrement();
 	}
 }
 
@@ -86,14 +106,22 @@ import ReactiveStore from '@brightspace-ui/labs/utilites/reactive-store.js';
 class MyStore extends ReactiveStore {
 	static get properties() {
 		return {
-			foo: { type: Number },
+			count: { type: Number },
 		};
 	}
 
 	constructor() {
 		super();
 
-		this.foo = 0;
+		this.count = 0;
+	}
+
+	increment() {
+		this.count++;
+	}
+
+	decrement() {
+		this.count--;
 	}
 }
 
@@ -127,16 +155,28 @@ class MyComponent extends LitElement {
 		// The provider will have all the same properties defined in your store, so you can
 		// access your store data from the provider if you wish.
 		return html`
-			<div>Foo: ${this.myStoreProvider.foo}</div>
-			<button @click=${this._click}>Update foo</button>
+			<div>Count: ${this.myStoreProvider.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 			<my-descendant-component></my-descendant-component>
 		`;
 	}
 
-	_click() {
+	_reset() {
 		// Updating the values from the provider will update the store, which will then
 		// notify all consumers of the changes and trigger component updates.
-		this.myStoreProvider.foo += 1;
+		this.myStoreProvider.count = 0;
+	}
+
+	_increment() {
+		// You can access any method or property defined in the store, not just reactive properties.
+		this.myStoreProvider.increment();
+	}
+
+	_decrement() {
+		// You can access any method or property defined in the store, not just reactive properties.
+		this.myStoreProvider.decrement();
 	}
 }
 
@@ -162,16 +202,28 @@ class MyDescendantComponent extends LitElement {
 	render() {
 		// The consumer will have all the same properties defined in your store.
 		return html`
-			<div>Foo: ${this.myStoreConsumer.foo}</div>
-			<button @click=${this._click}>Update foo</button>
+			<div>Count: ${this.myStoreConsumer.count}</div>
+			<button @click=${this._increment}>Increment</button>
+			<button @click=${this._decrement}>Decrement</button>
+			<button @click=${this._reset}>Reset</button>
 		`;
 	}
 
-	_click() {
+	_reset() {
 		// Updating the values from the consumer will update the store, which will then
 		// notify all consumers of the changes and trigger component updates for all consumers and
 		// the provider as well.
-		this.myStoreConsumer.foo += 1;
+		this.myStoreConsumer.count = 0;
+	}
+
+	_increment() {
+		// You can access any method or property defined in the store, not just reactive properties.
+		this.myStoreConsumer.increment();
+	}
+
+	_decrement() {
+		// You can access any method or property defined in the store, not just reactive properties.
+		this.myStoreConsumer.decrement();
 	}
 }
 
@@ -193,14 +245,14 @@ import ReactiveStore from '@brightspace-ui/labs/utilites/reactive-store.js';
 class MyStore extends ReactiveStore {
 	static get properties() {
 		return {
-			foo: { type: Number },
+			count: { type: Number },
 		};
 	}
 
 	constructor() {
 		super();
 
-		this.foo = 0;
+		this.count = 0;
 	}
 }
 
@@ -220,7 +272,7 @@ function handlePropertyChange({ property, value, prevValue }) {
 myStore.subscribe(handlePropertyChange);
 
 // When a store property is changed, any subscribed callback functions will be invoked synchronously
-myStore.foo += 1; // console: The "foo" property changed from 0 to 1
+myStore.count += 1; // console: The "count" property changed from 0 to 1
 
 // Unsubscribe your callback function when you no longer want to receive store updates
 myStore.unsubscribe(handlePropertyChange);
@@ -324,17 +376,19 @@ If the callback function passed in does not match a currently subscribed functio
 
 This is the class that is returned by the `createConsumer()` instance method on an instance of the store.
 
-This class is a [Lit Reactive Controller](https://lit.dev/docs/composition/controllers/) that when instantiated can be used by a Lit component to connect to the originating store instance.
+This class is a [Lit Reactive Controller](https://lit.dev/docs/composition/controllers/) that when instantiated acts as a proxy for the originating store itself.
 
-Any Consumer class instances will have access to all the same properties that the originating store does and will automatically trigger the update cycle on the host component whenever a property of the store changes.
+Any Consumer class instances will have access to all the same properties and methods that the originating store does and will automatically trigger the update cycle on the host component whenever a reactive property of the store changes.
 
 ### Instance Properties
 
-#### The Reactive `properties`
+#### Proxied Properties and Methods
 
-Just like the store has a set of properties dynamically generated, the Consumer class will have the same property accessors generated at construction time. The Consumer's properties will be directly connected to the corresponding properties on the originating store instance, so they can be used as if connecting to the store directly.
+Since the Consumer acts as a proxy for the originating store, all properties and methods from the original store will also be accessible from the Consumer. The Consumer's properties will be directly connected to the corresponding properties on the originating store instance, so they can be used as if interacting with the store directly.
 
-Setting any of these properties will call the corresponding setter on the originating store, and since the store notifies all consumers of changes, all consumers will then trigger the update cycle for their respective host components.
+The proxied properties and methods includes methods on the `ReactiveStore` base class like `forceUpdate`, `subscribe`, `unsubscribe`, etc. However, any properties/methods that conflict with the properties/methods defined by the Consumer class itself (`changedProperties`, `hostDisconnected`, etc.) will be ignored.
+
+Since updating a reactive property on the Consumer is the same as setting it on the store, updating a reactive property will notify all consumers of changes and, in turn, all consumers will then trigger the update cycle for their respective host components.
 
 #### `changedProperties`
 
@@ -356,10 +410,6 @@ The constructor for the Consumer class accepts the following parameters:
 |---|---|---|---|
 | `host` | LitElement | The host Lit element that the Consumer is to be connected to. | True |
 
-#### `forceUpdate()`
-
-This method can be used to call the originating store's own `forceUpdate()` method, which will trigger an update for all consumer host components. See the store's `forceUpdate()` definition for additional details.
-
 ## The context `Provider` class
 
 The context `Provider` class is one of the two [Lit Reactive Controllers](https://lit.dev/docs/composition/controllers/) returned by the `createContextControllers()` static method. The context `Consumer` class is the other controller returned and both of these act as a pair. Both of these controllers also have ther functionality tied to the specific store class you used to generate them.
@@ -370,11 +420,13 @@ This class is based on (and internally uses) the `ContextProvider` class from Li
 
 ### Instance Properties
 
-#### The Reactive `properties`
+#### Proxied Properties and Methods
 
-Just like the store has a set of properties dynamically generated, the context `Provider` class will have the same property accessors generated at construction time. The `Provider`'s properties will be directly connected to the corresponding properties on the store instance that it provides, so they can be used as if connecting to the store directly.
+The context `Provider` acts as a proxy for the originating store, which means that all properties and methods from the original store will also be accessible from the `Provider`. The `Provider`'s properties will be directly connected to the corresponding properties on the originating store instance, so they can be used as if interacting with the store directly.
 
-Setting any of these properties will call the corresponding setter on the provided store and the Provider will trigger a corresponding lifecycle update for its hosting component. Any context `Consumer` instances that are descendants of the `Provider` will also trigger the lifecycle update for their corresponding hosting components.
+The proxied properties and methods includes methods on the `ReactiveStore` base class like `forceUpdate`, `subscribe`, `unsubscribe`, etc. However, any properties/methods that conflict with the properties/methods defined by the `Provider` class itself (`changedProperties`, `hostDisconnected`, etc.) will be ignored.
+
+Since updating a reactive property on the `Provider` is the same as setting it on the store, updating a reactive property will notify the `Provider` and all descendant `Consumer` instances of changes and, in turn, the `Provider` and `Consumer` instances will then trigger the update cycle for their respective host components.
 
 #### `changedProperties`
 
@@ -397,10 +449,6 @@ The constructor for the context `Provider` class accepts the following parameter
 | `host` | LitElement instance | The host Lit element that the `Provider` is to be connected to. | True | |
 | `store` | ReactiveStore instance | The instance of your store that you wish to provide to descendant context `Consumer` classes. Note that if no store instance is passed to this parameter, an instance of your store will be instantiated to be used. | True | `new StoreClass()` |
 
-#### `forceUpdate()`
-
-This method can be used to call the provided store's own `forceUpdate()` method, which will trigger an update for the `Provider`'s host component as well as all context `Consumer` host components. See the store's `forceUpdate()` definition for additional details.
-
 ## The context `Consumer` class
 
 The context `Consumer` class is one of the two [Lit Reactive Controllers](https://lit.dev/docs/composition/controllers/) returned by the `createContextControllers()` static method. The context `Provider` class is the other controller returned and both of these act as a pair. Both of these controllers also have ther functionality tied to the specific store class you used to generate them.
@@ -413,11 +461,13 @@ This class is based on (and internally uses) the `ContextConsumer` class from Li
 
 ### Instance Properties
 
-#### The Reactive `properties`
+#### Proxied Properties and Methods
 
-Just like the store has a set of properties dynamically generated, the context `Consumer` class will have the same property accessors generated at construction time. The `Consumer`'s properties will be directly connected to the corresponding properties on the store instance that it receives from the context `Provider` ancestor, so they can be used as if connecting to the store directly.
+The context `Consumer` acts as a proxy for the originating store (which it receives from the `Provider` ancestor), which means that all properties and methods from the original store will also be accessible from the `Consumer`. The `Consumer`'s properties will be directly connected to the corresponding properties on the originating store instance, so they can be used as if interacting with the store directly.
 
-Setting any of these properties will call the corresponding setter on the provided store and the `Provider` will trigger a corresponding lifecycle update for its hosting component. Any context `Consumer` instances (including this one) that are descendants of that `Provider` will also trigger the lifecycle update for their corresponding hosting components.
+The proxied properties and methods includes methods on the `ReactiveStore` base class like `forceUpdate`, `subscribe`, `unsubscribe`, etc. However, any properties/methods that conflict with the properties/methods defined by the `Consumer` class itself (`changedProperties`, `hostDisconnected`, etc.) will be ignored.
+
+Since updating a reactive property on the `Consumer` is the same as setting it on the store, updating a reactive property will notify the `Provider` and all descendant `Consumer` instances of changes and, in turn, the `Provider` and `Consumer` instances will then trigger the update cycle for their respective host components.
 
 #### `changedProperties`
 
@@ -438,7 +488,3 @@ The constructor for the context `Consumer` class accepts the following parameter
 | Parameter Name | Type | Description | Required |
 |---|---|---|---|
 | `host` | LitElement instance | The host Lit element that the `Consumer` is to be connected to. | True |
-
-#### `forceUpdate()`
-
-This method can be used to call the provided store's own `forceUpdate()` method, which will trigger an update for the `Provider`'s host component as well as all context `Consumer` host components. See the store's `forceUpdate()` definition for additional details.

--- a/src/utilities/reactive-store/store-reactor.js
+++ b/src/utilities/reactive-store/store-reactor.js
@@ -1,0 +1,52 @@
+export default class StoreReactor {
+	changedProperties;
+
+	constructor(host, store, properties = store.constructor.properties) {
+		this.#host = host;
+		this.#host.addController(this);
+		this.#store = store;
+
+		this.changedProperties = new Map();
+
+		this.#store.subscribe(this.#onPropertyChange);
+
+		this.#initializeChangedProperties(properties);
+	}
+
+	hostDisconnected() {
+		this.#store.unsubscribe(this.#onPropertyChange);
+	}
+
+	#host;
+	#store;
+
+	#onPropertyChange = ({
+		property,
+		prevValue,
+		forceUpdate = false,
+	}) => {
+		if (!forceUpdate && !this.changedProperties.has(property)) this.changedProperties.set(property, prevValue);
+
+		this.#host.requestUpdate();
+		this.#host.updateComplete.then(() => {
+			this.changedProperties.clear();
+		});
+	};
+
+	#initializeChangedProperties(properties) {
+		let shouldUpdate = false;
+		Object.keys(properties).forEach((property) => {
+			if (this.#store[property] === undefined) return;
+
+			this.changedProperties.set(property, undefined);
+			shouldUpdate = true;
+		});
+
+		if (!shouldUpdate) return;
+
+		this.#host.requestUpdate();
+		this.#host.updateComplete.then(() => {
+			this.changedProperties.clear();
+		});
+	}
+}

--- a/test/utilities/reactive-store/context-controllers.test.js
+++ b/test/utilities/reactive-store/context-controllers.test.js
@@ -18,6 +18,12 @@ class TestStore1 extends ReactiveStore {
 		this.objectProp = {
 			nestedProp: 'default'
 		};
+
+		this.nonReactiveProp = 'default';
+	}
+
+	testMethod() {
+		return 'test';
 	}
 }
 const { Provider: Provider1, Consumer: Consumer1 } = TestStore1.createContextControllers();
@@ -58,6 +64,7 @@ class HostingComponent extends LitElement {
 			<div id="prop1">${this.storeProvider1.prop1}</div>
 			<div id="prop2">${this.storeProvider1.prop2}</div>
 			<div id="nestedProp">${this.storeProvider1.objectProp.nestedProp}</div>
+			<div id="nonReactiveProp">${this.storeProvider1.nonReactiveProp}</div>
 			<div id="foo">${this.storeProvider2.foo}</div>
 			<div id="bar">${this.storeProvider2.bar}</div>
 
@@ -101,6 +108,7 @@ class ConsumingComponent extends LitElement {
 			<div id="prop1">${this.storeConsumer1.prop1}</div>
 			<div id="prop2">${this.storeConsumer1.prop2}</div>
 			<div id="nestedProp">${this.storeConsumer1.objectProp.nestedProp}</div>
+			<div id="nonReactiveProp">${this.storeConsumer1.nonReactiveProp}</div>
 			<div id="foo">${this.storeConsumer2.foo}</div>
 			<div id="bar">${this.storeConsumer2.bar}</div>
 		`;
@@ -329,6 +337,44 @@ describe('ReactiveStore Context Controllers', () => {
 				});
 			});
 		});
+
+		describe('non-reactive properties and methods', () => {
+			it('should reflect the store non-reactive properties and methods', async() => {
+				const hostingComponent = await fixture(basicFixture);
+
+				expect(hostingComponent.storeProvider1.nonReactiveProp).to.equal('default');
+				expect(hostingComponent.storeProvider1.testMethod()).to.equal('test');
+
+				hostingComponent.storeProvider1.nonReactiveProp = 'value1';
+				expect(hostingComponent.storeProvider1.nonReactiveProp).to.equal('value1');
+			});
+
+			it('non-reactive properties should not trigger an update', async() => {
+				const hostingComponent = await fixture(basicFixture);
+
+				verifyRenderedValues(hostingComponent, {
+					nonReactiveProp: 'default',
+				});
+
+				hostingComponent.storeProvider1.nonReactiveProp = 'value1';
+
+				await hostingComponent.updateComplete;
+
+				verifyRenderedValues(hostingComponent, {
+					nonReactiveProp: 'default',
+				});
+			});
+
+			it('non-reactive properties should not be in changedProperties', async() => {
+				const hostingComponent = await fixture(basicFixture);
+
+				hostingComponent.storeProvider1.nonReactiveProp = 'value1';
+
+				await hostingComponent.updateComplete;
+
+				expect(hostingComponent.storeProvider1.changedProperties.has('nonReactiveProp')).to.be.false;
+			});
+		});
 	});
 
 	describe('Consumer', () => {
@@ -469,6 +515,47 @@ describe('ReactiveStore Context Controllers', () => {
 				verifyRenderedValues(consumingComponent2, {
 					nestedProp: 'default',
 				});
+			});
+		});
+
+		describe('non-reactive properties and methods', () => {
+			it('should reflect the store non-reactive properties and methods', async() => {
+				const hostingComponent = await fixture(basicFixture);
+				const consumingComponent = hostingComponent.consumingComponent;
+
+				expect(consumingComponent.storeConsumer1.nonReactiveProp).to.equal('default');
+				expect(consumingComponent.storeConsumer1.testMethod()).to.equal('test');
+
+				consumingComponent.storeConsumer1.nonReactiveProp = 'value1';
+				expect(consumingComponent.storeConsumer1.nonReactiveProp).to.equal('value1');
+			});
+
+			it('non-reactive properties should not trigger an update', async() => {
+				const hostingComponent = await fixture(basicFixture);
+				const consumingComponent = hostingComponent.consumingComponent;
+
+				verifyRenderedValues(consumingComponent, {
+					nonReactiveProp: 'default',
+				});
+
+				consumingComponent.storeConsumer1.nonReactiveProp = 'value1';
+
+				await consumingComponent.updateComplete;
+
+				verifyRenderedValues(consumingComponent, {
+					nonReactiveProp: 'default',
+				});
+			});
+
+			it('non-reactive properties should not be in changedProperties', async() => {
+				const hostingComponent = await fixture(basicFixture);
+				const consumingComponent = hostingComponent.consumingComponent;
+
+				consumingComponent.storeConsumer1.nonReactiveProp = 'value1';
+
+				await consumingComponent.updateComplete;
+
+				expect(consumingComponent.storeConsumer1.changedProperties.has('nonReactiveProp')).to.be.false;
 			});
 		});
 	});

--- a/test/utilities/reactive-store/store-consumer.test.js
+++ b/test/utilities/reactive-store/store-consumer.test.js
@@ -13,6 +13,12 @@ class TestStore extends ReactiveStore {
 		super();
 		this.prop1 = 'default';
 		this.prop2 = 'default';
+
+		this.nonReactiveProp = 'default';
+	}
+
+	testMethod() {
+		return 'test';
 	}
 }
 
@@ -206,6 +212,36 @@ describe('ReactiveStore StoreConsumer', () => {
 			storeConsumer.forceUpdate();
 
 			expect(forceUpdateCallCount).to.equal(1);
+		});
+	});
+
+	describe('non-reactive properties and methods', () => {
+		it('should reflect the store non-reactive properties and methods', () => {
+			const storeConsumer = new StoreConsumer(host, store);
+
+			expect(storeConsumer.nonReactiveProp).to.equal('default');
+			expect(storeConsumer.testMethod()).to.equal('test');
+
+			store.nonReactiveProp = 'value';
+			expect(storeConsumer.nonReactiveProp).to.equal('value');
+		});
+
+		it('non-reactive properties should not call requestUpdate', () => {
+			const storeConsumer = new StoreConsumer(host, store);
+
+			const requestUpdateCallCount = host.requestUpdateCallCount;
+
+			storeConsumer.nonReactiveProp = 'value';
+
+			expect(host.requestUpdateCallCount).to.equal(requestUpdateCallCount);
+		});
+
+		it('non-reactive properties should not be in changedProperties', async() => {
+			const storeConsumer = new StoreConsumer(host, store);
+
+			storeConsumer.nonReactiveProp = 'value';
+
+			expect(storeConsumer.changedProperties.has('nonReactiveProp')).to.be.false;
 		});
 	});
 });


### PR DESCRIPTION
This change makes it so the `StoreConsumer` and the context `Provider`/`Consumer` pair are instantiated as proxies for the store they're connecting to.

This makes it possible for all methods and properties defined within the store (not just ones defined in the static `properties`) to be accessed and used from any consumer.

Did this work as part of this refactor: https://desire2learn.atlassian.net/browse/MED-1354