### PR TITLE
MED-1431 Make sure the ReactiveStore supports reactive property inheritance

### DIFF
--- a/src/utilities/reactive-store/reactive-store.js
+++ b/src/utilities/reactive-store/reactive-store.js
@@ -12,7 +12,8 @@ export default class ReactiveStore {
 	constructor() {
 		this._pubSub = new PubSub();
 		this._state = {};
-		this._defineProperties(this.constructor.properties);
+
+		this.#defineProperties(this.constructor.prototype);
 	}
 
 	createConsumer() {
@@ -36,7 +37,13 @@ export default class ReactiveStore {
 		this._pubSub.unsubscribe(callback);
 	}
 
-	_defineProperties(properties) {
+	#defineProperties(proto) {
+		if (!(proto instanceof ReactiveStore)) return;
+		this.#defineProperties(Object.getPrototypeOf(proto));
+
+		const { properties } = proto.constructor;
+		if (!properties) return;
+
 		Object.keys(properties).forEach((property) => {
 			Object.defineProperty(this, property, {
 				get() {

--- a/test/utilities/reactive-store/reactive-store.test.js
+++ b/test/utilities/reactive-store/reactive-store.test.js
@@ -135,6 +135,42 @@ describe('ReactiveStore', () => {
 			expect(callbackStub1.calls.length).to.equal(1);
 			expect(callbackStub2.calls.length).to.equal(1);
 		});
+
+		it('should inherit properties from parent classes', () => {
+			class ParentStore extends ReactiveStore {
+				static properties = {
+					prop1: {}
+				};
+			}
+
+			class ChildStore extends ParentStore {
+				static properties = {
+					prop2: {}
+				};
+			}
+
+			const store = new ChildStore();
+			const callbackStub = new CallbackStub();
+			store.subscribe(callbackStub.callback);
+
+			store.prop1 = 'value1';
+			expect(callbackStub.calls.length).to.equal(1);
+			expect(callbackStub.calls[0][0]).to.deep.equal({
+				property: 'prop1',
+				value: 'value1',
+				prevValue: undefined,
+				forceUpdate: false
+			});
+
+			store.prop2 = 'value2';
+			expect(callbackStub.calls.length).to.equal(2);
+			expect(callbackStub.calls[1][0]).to.deep.equal({
+				property: 'prop2',
+				value: 'value2',
+				prevValue: undefined,
+				forceUpdate: false
+			});
+		});
 	});
 
 	describe('createConsumer()', () => {


### PR DESCRIPTION
This fixes an issue with the original implementation that made it so extending a previously defined ReactiveStore and implementing new reactive properties would override any previous reactive properties. With this fix, properties inherited from ancestors will be implemented before descendants.