### PR TITLE
MED-1431 Support inherited properties when initializing changedProperties

### DIFF
--- a/src/utilities/reactive-store/constants.js
+++ b/src/utilities/reactive-store/constants.js
@@ -1,0 +1,1 @@
+export const combinedPropertiesSymbol = Symbol('combinedProperties');

--- a/src/utilities/reactive-store/context-controllers.js
+++ b/src/utilities/reactive-store/context-controllers.js
@@ -3,11 +3,12 @@ import {
 	ContextConsumer as LitContextConsumer,
 	ContextProvider as LitContextProvider
 } from '@lit/context';
+import { combinedPropertiesSymbol } from './constants.js';
 import StoreReactor from './store-reactor.js';
 
 export class ContextProvider {
 	constructor(host, StoreClass, store = new StoreClass()) {
-		const { properties } = StoreClass;
+		const properties = StoreClass[combinedPropertiesSymbol];
 		const storeReactor = new StoreReactor(host, store, properties);
 		new LitContextProvider(host, {
 			context: createContext(StoreClass),
@@ -31,7 +32,7 @@ export class ContextProvider {
 }
 export class ContextConsumer {
 	constructor(host, StoreClass) {
-		const { properties } = StoreClass;
+		const properties = StoreClass[combinedPropertiesSymbol];
 		const target = {
 			store: {},
 			storeReactor: {},

--- a/src/utilities/reactive-store/store-consumer.js
+++ b/src/utilities/reactive-store/store-consumer.js
@@ -1,7 +1,8 @@
+import { combinedPropertiesSymbol } from './constants.js';
 import StoreReactor from './store-reactor.js';
 
 export default class StoreConsumer {
-	constructor(host, store, properties = store.constructor.properties) {
+	constructor(host, store, properties = store.constructor[combinedPropertiesSymbol]) {
 		const storeReactor = new StoreReactor(host, store, properties);
 
 		return new Proxy(store, {

--- a/src/utilities/reactive-store/store-reactor.js
+++ b/src/utilities/reactive-store/store-reactor.js
@@ -1,7 +1,9 @@
+import { combinedPropertiesSymbol } from './constants.js';
+
 export default class StoreReactor {
 	changedProperties;
 
-	constructor(host, store, properties = store.constructor.properties) {
+	constructor(host, store, properties = store.constructor[combinedPropertiesSymbol]) {
 		this.#host = host;
 		this.#host.addController(this);
 		this.#store = store;

--- a/test/utilities/reactive-store/store-consumer.test.js
+++ b/test/utilities/reactive-store/store-consumer.test.js
@@ -119,6 +119,41 @@ describe('ReactiveStore StoreConsumer', () => {
 			const storeConsumer = new StoreConsumer(host, store);
 
 			expect(storeConsumer.changedProperties.size).to.equal(2);
+			expect(storeConsumer.changedProperties.has('prop1')).to.be.true;
+			expect(storeConsumer.changedProperties.has('prop2')).to.be.true;
+			expect(storeConsumer.changedProperties.get('prop1')).to.equal(undefined);
+			expect(storeConsumer.changedProperties.get('prop2')).to.equal(undefined);
+		});
+
+		it('should contain undefined for initialized parent properties during the initial update cycle', () => {
+			class ParentStore extends ReactiveStore {
+				static properties = {
+					prop1: {}
+				};
+
+				constructor() {
+					super();
+					this.prop1 = 'default';
+				}
+			}
+
+			class ChildStore extends ParentStore {
+				static properties = {
+					prop2: {}
+				};
+
+				constructor() {
+					super();
+					this.prop2 = 'default';
+				}
+			}
+
+			const store = new ChildStore();
+			const storeConsumer = new StoreConsumer(host, store);
+
+			expect(storeConsumer.changedProperties.size).to.equal(2);
+			expect(storeConsumer.changedProperties.has('prop1')).to.be.true;
+			expect(storeConsumer.changedProperties.has('prop2')).to.be.true;
 			expect(storeConsumer.changedProperties.get('prop1')).to.equal(undefined);
 			expect(storeConsumer.changedProperties.get('prop2')).to.equal(undefined);
 		});


### PR DESCRIPTION
Related to https://github.com/BrightspaceUI/labs/pull/549
I missed applying the same fix to the `changedProperties` initialization process.