### PR TITLE
fix: accessibility issues with navigation

### DIFF
--- a/demo/components/navigation/button-link.html
+++ b/demo/components/navigation/button-link.html
@@ -76,7 +76,7 @@
 					<d2l-labs-navigation-dropdown-button-icon icon="tier3:discussions" text="Subscription alerts" has-notification notification-text="You have new subscription alerts">
 						<d2l-dropdown-content vertical-offset="0">Subscription alerts in here.</d2l-dropdown-content>
 					</d2l-labs-navigation-dropdown-button-icon>
-					<d2l-labs-navigation-dropdown-button-custom>
+					<d2l-labs-navigation-dropdown-button-custom opener-label="User Name, avatar">
 						<span class="personal-menu" slot="opener">
 							<span class="personal-menu-square"></span>
 							User Name

--- a/src/components/navigation/navigation-dropdown-button-custom.js
+++ b/src/components/navigation/navigation-dropdown-button-custom.js
@@ -7,8 +7,7 @@ class NavigationDropdownButtonCustom extends DropdownOpenerMixin(LitElement) {
 
 	static get properties() {
 		return {
-			openerLabel: { type: String, attribute: 'opener-label' },
-			openerLabelledby: { type: String, attribute: 'opener-labelledby' }
+			openerLabel: { type: String, attribute: 'opener-label' }
 		};
 	}
 
@@ -30,8 +29,7 @@ class NavigationDropdownButtonCustom extends DropdownOpenerMixin(LitElement) {
 			<button
 				type="button"
 				aria-haspopup="menu"
-				aria-label="${ifDefined(this.openerLabel)}"
-				aria-labelledby="${ifDefined(this.openerLabelledby)}">
+				aria-label="${ifDefined(this.openerLabel)}">
 				<span class="d2l-labs-navigation-highlight-border"></span>
 				<slot name="opener"></slot>
 			</button>

--- a/src/components/navigation/navigation-dropdown-button-custom.js
+++ b/src/components/navigation/navigation-dropdown-button-custom.js
@@ -1,8 +1,16 @@
 import { css, html, LitElement } from 'lit';
 import { highlightBorderStyles, highlightButtonStyles } from './navigation-styles.js';
 import { DropdownOpenerMixin } from '@brightspace-ui/core/components/dropdown/dropdown-opener-mixin.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 class NavigationDropdownButtonCustom extends DropdownOpenerMixin(LitElement) {
+
+	static get properties() {
+		return {
+			openerLabel: { type: String, attribute: 'opener-label' },
+			openerLabelledby: { type: String, attribute: 'opener-labelledby' }
+		};
+	}
 
 	static get styles() {
 		return [highlightBorderStyles, highlightButtonStyles, css`
@@ -19,7 +27,11 @@ class NavigationDropdownButtonCustom extends DropdownOpenerMixin(LitElement) {
 
 	render() {
 		return html`
-			<button type="button">
+			<button
+				type="button"
+				aria-haspopup="menu"
+				aria-label="${ifDefined(this.openerLabel)}"
+				aria-labelledby="${ifDefined(this.openerLabelledby)}">
 				<span class="d2l-labs-navigation-highlight-border"></span>
 				<slot name="opener"></slot>
 			</button>

--- a/src/components/navigation/navigation-skip.js
+++ b/src/components/navigation/navigation-skip.js
@@ -44,6 +44,8 @@ class NavigationSkip extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 	}
 
 	render() {
+		// Href attribute is needed for a11y tools to recognize anchor as a link
+		// and for click events to be dispatched using key presses
 		return html`<a href="javascript:void(0);" class="vdiff-target">${this.text}</a>`;
 	}
 

--- a/src/components/navigation/navigation-skip.js
+++ b/src/components/navigation/navigation-skip.js
@@ -44,14 +44,7 @@ class NavigationSkip extends FocusMixin(PropertyRequiredMixin(LitElement)) {
 	}
 
 	render() {
-		return html`<a tabindex="0" @keydown="${this._handleKeyDown}" class="vdiff-target">${this.text}</a>`;
-	}
-
-	_handleKeyDown(e) {
-		if (e.keyCode === 13) {
-			e.preventDefault();
-			this.dispatchEvent(new CustomEvent('click', { bubbles: true, composed: true }));
-		}
+		return html`<a href="javascript:void(0);" class="vdiff-target">${this.text}</a>`;
 	}
 
 }


### PR DESCRIPTION
[JIRA](https://desire2learn.atlassian.net/browse/GAUD-7686)

Adding the void `href` on navigation-skip makes the anchor dispatch click events for keyboard. It also announces the anchor as a link which it was not doing before. 

[JIRA](https://desire2learn.atlassian.net/browse/GAUD-7688)

Adding label properties to add them to the underlying button instead of the custom opener component. NVDA does not seem to like the custom component having labels or ids(no idea why the latter is the case).
