### PR TITLE
GAUD-7818 - Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 *       @BrightspaceUI/gaudi-dev
-package-lock.json
-
 **/media-player	@BrightspaceUI/Media
+
+golden/
+.vdiff.json
+package-lock.json


### PR DESCRIPTION
Align this to match [`core`'s `CODEOWNERS` file](https://github.com/BrightspaceUI/core/blob/e4726cdab1f942e0af171e808c43f7435a3a9540/.github/CODEOWNERS).