### PR TITLE
GAUD-7947 - Cleanup grade-result docs

### DIFF
--- a/src/components/grade-result/README.md
+++ b/src/components/grade-result/README.md
@@ -1,10 +1,10 @@
-# Grade Results
+# Grade Result
 
 Components used for rendering grades in Brightspace.
 
 ## Presentation View [d2l-labs-grade-result-presentational]
 
-<!-- docs: demo -->
+<!-- docs: demo code -->
 ```html
 <script type="module">
   import '@brightspace-ui/labs/components/grade-result/grade-result-presentational.js';
@@ -16,7 +16,27 @@ Components used for rendering grades in Brightspace.
   scoreNumerator="5"
   scoreDenominator="20"
   display-student-grade-preview
-  student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
+  student-grade-preview='{"score": 5, "symbol": "Fine", "colour": "#FFCC00"}'
+></d2l-labs-grade-result-presentational>
+```
+
+<!-- docs: demo code -->
+```html
+<script type="module">
+  import '@brightspace-ui/labs/components/grade-result/grade-result-presentational.js';
+</script>
+<d2l-labs-grade-result-presentational
+  gradeType="Numeric"
+  labelText="Overall Grade"
+  scoreNumerator="5"
+  scoreDenominator="20"
+  isManualOverrideActive
+  includeGradeButton
+  gradeButtonTooltip="Assignment 1 Grade Item Attached"
+  includeReportsButton
+  reportsButtonTooltip="Class and user statistics"
+  display-student-grade-preview
+  student-grade-preview='{"score": 10, "symbol": "Very Good", "colour": "#00FFFF"}'
 ></d2l-labs-grade-result-presentational>
 ```
 
@@ -60,7 +80,7 @@ Components used for rendering grades in Brightspace.
 
 ## Student Grade Preview [d2l-labs-grade-result-student-grade-preview]
 
-<!-- docs: demo -->
+<!-- docs: demo code -->
 ```html
 <script type="module">
   import '@brightspace-ui/labs/components/grade-result/grade-result-student-grade-preview.js';

--- a/src/components/grade-result/README.md
+++ b/src/components/grade-result/README.md
@@ -26,9 +26,10 @@ Components used for rendering grades in Brightspace.
   import '@brightspace-ui/labs/components/grade-result/grade-result-presentational.js';
 </script>
 <d2l-labs-grade-result-presentational
-  gradeType="Numeric"
+  gradeType="LetterGrade"
   labelText="Overall Grade"
-  scoreNumerator="5"
+  letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+  selectedLetterGrade="2"
   scoreDenominator="20"
   isManualOverrideActive
   includeGradeButton

--- a/src/components/grade-result/README.md
+++ b/src/components/grade-result/README.md
@@ -1,30 +1,28 @@
-# @d2l/labs-grade-result
+# Grade Results
 
-A web component used for rendering grades in Brightspace
+Components used for rendering grades in Brightspace.
 
-## Properties
+## Presentation View [d2l-labs-grade-result-presentational]
 
-#### d2l-labs-d2l-grade-result
+<!-- docs: demo -->
+```html
+<script type="module">
+  import '@brightspace-ui/labs/components/grade-result/grade-result-presentational.js';
+</script>
+<d2l-labs-grade-result-presentational
+  gradeType="Numeric"
+  labelText="Overall Grade"
+  labelHeadingLevel="3"
+  scoreNumerator="5"
+  scoreDenominator="20"
+  display-student-grade-preview
+  student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
+></d2l-labs-grade-result-presentational>
+```
 
-| Property                          | Type      | Default     | Description                                                  |
-| ----------------------------------| --------- | -------     | ------------------------------------------------------------ |
-| `href`                            | `string`  | `''`        | The Hypermedia route to power the component. This component runs off of the /grade route or an activity. |
-| `token`                           | `string`  | `''`        | For authentication                                           |
-| `disableAutoSave`                 | `boolean` | `false`     | Prevent the component from automatically saving the grade to the API when the grade is changed. |
-| `_hideTitle`                      | `boolean` | `false`     | This property will hide the "Overall Grade" title above the component. |
-| `customManualOverrideText`        | `string`  | `undefined` | This properly will substitute the stock text on the "Manual Override" button. |
-| `customManualOverrideClearText`   | `string`  | `undefined` | This properly will substitute the stock text on the "Clear Manual Override" button. |
+<!-- docs: start hidden content -->
 
-##### Public Methods
-
-| Method                         | Description                                                  |
-| ------------------------------ | ------------------------------------------------------------ |
-| `saveGrade(): void`            | This is the method used to manually save the grade to the server when `disableAutoSave = true`. This method will emit `@d2l-grade-result-grade-saved-success` or `@d2l-grade-result-grade-saved-error`. |
-| `hasUnsavedChanges(): boolean` | Determines whether the grade has been changed by the user and has not been saved to the server yet. |
-
-If you are only interested in rendering the presentational layer of the component, you can simply use the `d2l-grade-result-presentational` component.
-
-#### d2l-labs-grade-result-presentational
+### Properties
 
 | Property                          | GradeType      | Type                        | Default     | Description                                                  |
 | ----------------------------------| -------------- | --------------------------- | ----------- | ------------------------------------------------------------ |
@@ -48,23 +46,7 @@ If you are only interested in rendering the presentational layer of the componen
 | `allowNegativeScore`             | Numeric        | `boolean`                    | `'false'`   | Set to `true` if negative scores can be entered                         |
 | `showFlooredScoreWarning`        | Numeric        | `boolean`                    | `'false'`   | Set to `true` if displaying a negative grade that has been floored at 0 |
 
-## Events
-
-#### d2l-labs-d2l-grade-result
-
-| Event                                           | Description                                                  |
-| ----------------------------------------------- | ------------------------------------------------------------ |
-| `@d2l-grade-result-initialized-success`         | This event is fired when the component is successfully initialized and a grade is loaded from the API. |
-| `@d2l-grade-result-initialized-error`           | This event is fired when there is an error initializing the component. This is usually caused by an invalid `href` or `token`. |
-| `@d2l-grade-result-grade-updated-success`       | This event is fired when the grade is successfully updated on the frontend. |
-| `@d2l-grade-result-grade-updated-error`         | This event is fired when there is an error updating the grade on the frontend. |
-| `@d2l-grade-result-grade-saved-success`         | This event is fired when the grade is successfully saved to the server. |
-| `@d2l-grade-result-grade-saved-error`           | This event is fired when there is an error while saving the grade to the server. |
-| `@d2l-grade-result-grade-button-click`          | This event is fired when the grades button is clicked.       |
-| `@d2l-grade-result-reports-button-click`        | This event is fired when the reports button is clicked.      |
-| `@d2l-grade-result-manual-override-clear-click` | This event is fired when the manual override clear is clicked. |
-
-#### d2l-labs-grade-result-presentational
+### Events
 
 | Event                                           | Description                                                  |
 | ----------------------------------------------- | ------------------------------------------------------------ |
@@ -74,12 +56,17 @@ If you are only interested in rendering the presentational layer of the componen
 | `@d2l-grade-result-letter-score-selected`       | This event is fired on the change of the grade for a `gradeType="LetterGrade"` grade. |
 | `@d2l-grade-result-manual-override-clear-click` | This event is fired when the manual override clear is clicked. |
 
+<!-- docs: end hidden content -->
 
-## Usage
+## Student Grade Preview [d2l-labs-grade-result-student-grade-preview]
 
+<!-- docs: demo -->
 ```html
 <script type="module">
-    import '@d2l/labs-grade-result/d2l-grade-result.js';
+  import '@brightspace-ui/labs/components/grade-result/grade-result-student-grade-preview.js';
 </script>
-<d2l-labs-d2l-grade-result href="href" token="token" disableAutoSave _hideTitle>My element</d2l-labs-d2l-grade-result>
+  <d2l-labs-grade-result-student-grade-preview
+    out-of="10"
+    student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
+  ></d2l-labs-grade-result-student-grade-preview>
 ```

--- a/src/components/grade-result/grade-result-letter-score.js
+++ b/src/components/grade-result/grade-result-letter-score.js
@@ -3,6 +3,9 @@ import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/s
 import { LocalizeLabsElement } from '../localize-labs-element.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 
+/**
+ * @fires d2l-grade-result-letter-score-selected - Dispatched on the change of the grade for a gradeType="LetterGrade" grade.
+ */
 export class D2LGradeResultLetterScore extends LocalizeLabsElement(LitElement) {
 
 	static get properties() {

--- a/src/components/grade-result/grade-result-numeric-score.js
+++ b/src/components/grade-result/grade-result-numeric-score.js
@@ -14,6 +14,9 @@ const MIN_WIDTH = 5.5;
 const MIN_NEGATIVE_GRADE = -9999999999;
 const MIN_POSITIVE_GRADE = 0;
 
+/**
+ * @fires d2l-grade-result-grade-change - Dispatched on the change of the grade for a gradeType="Numeric" grade.
+ */
 export class D2LGradeResultNumericScore extends LocalizeLabsElement(LitElement) {
 	static get properties() {
 		return {

--- a/src/components/grade-result/grade-result-presentational.js
+++ b/src/components/grade-result/grade-result-presentational.js
@@ -14,30 +14,120 @@ const numberConverter = {
 	toAttribute:  (prop) => { return String(prop); }
 };
 
+/**
+ * @fires d2l-grade-result-grade-button-click - Dispatched when the grade button is clicked.
+ * @fires d2l-grade-result-manual-override-clear-click - Dispatched when the manual override clear is clicked.
+ * @fires d2l-grade-result-reports-button-click - Dispatched when the reports button is clicked.
+ */
 export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement) {
 	static get properties() {
 		return {
+			/**
+			 * Set to true if negative scores can be entered
+			 * @type {boolean}
+			 */
 			allowNegativeScore: { type: Boolean },
+			/**
+			 * This property will substitute the stock text on the "Clear Manual Override" button
+			 * @type {string}
+			 */
 			customManualOverrideClearText: { type: String },
+			/**
+			 * @type {boolean}
+			 */
 			displayStudentGradePreview: { type: Boolean, attribute: 'display-student-grade-preview' },
+			/**
+			 * The text that is inside of the tooltip when hovering over the grades button
+			 * @type {string}
+			 */
 			gradeButtonTooltip: { type: String },
+			/**
+			 * Specifies the type of grade that the component is meant to render
+			 * @type {'Numeric'|'LetterGrade'}
+			 */
 			gradeType: { type: String },
+			/**
+			 * This property will hide the "Overall Grade" title above the component
+			 * @type {boolean}
+			 */
 			hideTitle: { type: Boolean },
+			/**
+			 * Determines whether the grades icon button is rendered
+			 * @type {boolean}
+			 */
 			includeGradeButton: { type: Boolean },
+			/**
+			 * Determines whether the reports icon button is rendered
+			 * @type {boolean}
+			 */
 			includeReportsButton: { type: Boolean },
+			/**
+			 * This property sets the label that will be used inside the aria-label and validation error tooltips
+			 * @type {string}
+			 */
 			inputLabelText: { type: String },
+			/**
+			 * Set to true if the user is currently manually overriding the grade. This will display the button to 'Clear Manual Override'.
+			 * @type {boolean}
+			 */
 			isManualOverrideActive: { type: Boolean },
+			/**
+			 * @type {number}
+			 */
 			labelHeadingLevel: { type: Number },
+			/**
+			 * The text that appears above the component
+			 * @type {string}
+			 */
 			labelText: { type: String },
+			/**
+			 * A dictionary where the key is a unique id and the value is an object containing the LetterGrade text and the PercentStart
+			 * @type {object}
+			 */
 			letterGradeOptions: { type: Object },
+			/**
+			 * Set to true if the user does not have permissions to edit the grade
+			 * @type {boolean}
+			 */
 			readOnly: { type: Boolean },
+			/**
+			 * The text that is inside of the tooltip when hovering over the reports button
+			 * @type {string}
+			 */
 			reportsButtonTooltip: { type: String },
+			/**
+			 * Set to true if an undefined/blank grade is not considered valid
+			 * @type {boolean}
+			 */
 			required: { type: Boolean },
+			/**
+			 * The denominator of the numeric score that is given
+			 * @type {number}
+			 */
 			scoreDenominator: { type: Number },
+			/**
+			 * The numerator of the numeric score that is given
+			 * @type {number}
+			 */
 			scoreNumerator: { type: Number, converter: numberConverter },
+			/**
+			 * The current selected letter grade of the options given
+			 * @type {string}
+			 */
 			selectedLetterGrade: { type: String },
+			/**
+			 * Set to true if displaying a negative grade that has been floored at 0
+			 * @type {boolean}
+			 */
 			showFlooredScoreWarning: { type: Boolean },
+			/**
+			 * This property will show the given text under the title
+			 * @type {string}
+			 */
 			subtitleText: { type: String },
+			/**
+			 * @type {object}
+			 */
 			studentGradePreview: { type: Object, attribute: 'student-grade-preview' },
 		};
 	}


### PR DESCRIPTION
Cleaning up the README to create a nicer page for the Daylight site.

I moved a lot of the README contents into the files in case we ever decide to hook up `labs` to create the `custom-elements.json` files. But I can revert that part if we want and just leave it in the README only.