### PR TITLE
PHNX-2820 Ensure Accordion Initial State Accuracy

### DIFF
--- a/src/components/accordion/accordion-collapse.js
+++ b/src/components/accordion/accordion-collapse.js
@@ -203,6 +203,9 @@ class LabsAccordionCollapse extends LitElement {
 			this.#resizeObserver = new ResizeObserver(() => this._fireAccordionResizeEvent());
 			this.#resizeObserver.observe(this);
 		}
+		if (this.opened) {
+			this._state = 'opened';
+		}
 	}
 	disconnectedCallback() {
 		super.disconnectedCallback();


### PR DESCRIPTION
## Relevant Jira Links
https://desire2learn.atlassian.net/browse/PHNX-2820

## Description
The first time you navigate to the content page in Sequence Launcher,  the first accordion menu item is opened by default, but the `_state` attribute of the `d2l-labs-accordion-collapse` element is set to `closed`.

## Goal/Solution
The `_state` of the first item should be set to `opened`.

This is done by checking by checking if the item has been `opened`. In `connectedCallback` (which runs when the element is connected to the DOM), we set the `_state` to `'open'` if this is the case. This ensures the item's `_state` is set correctly.

## Screenshots/Demo
![PHNX-2820](https://github.com/user-attachments/assets/c6e1de4c-bacd-4d93-ba28-725b66afe15c)


[PHNX-2820]: https://desire2learn.atlassian.net/browse/PHNX-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ