### PR TITLE
GAUD-8067 & GAUD-8071 - Clean up docs for ou-filter and wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "./controllers/computed-value.js": "./src/controllers/computed-values/computed-value.js",
     "./controllers/computed-values.js": "./src/controllers/computed-values/computed-values.js",
     "./controllers/language-listener.js": "./src/controllers/language-listener/language-listener.js",
+    "./demo/components/ou-filter/*.js": "./demo/components/ou-filter/*.js",
     "./utilities/pub-sub.js": "./src/utilities/pub-sub/pub-sub.js",
     "./utilities/reactive-store.js": "./src/utilities/reactive-store/reactive-store.js",
     "./utilities/lit-router": "./src/utilities/router/index.js"
@@ -93,7 +94,8 @@
   "files": [
     "labs.serge.json",
     "/src",
-    "/demo/components/media-player/static"
+    "/demo/components/media-player/static",
+    "/demo/components/ou-filter/*.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/src/components/ou-filter/README.md
+++ b/src/components/ou-filter/README.md
@@ -1,0 +1,74 @@
+# Org Unit Filter
+
+A Lit component that renders an org unit structure tree. It supports load more and searching functionality.
+
+## Org Unit Filter [d2l-labs-ou-filter]
+
+<!-- docs: demo align:flex-start autoSize:false size:xlarge -->
+```html
+<script type="module">
+  import '@brightspace-ui/labs/demo/components/ou-filter/ouFilterDemoPage.js';
+</script> 
+<d2l-labs-oufilter-demo-page></d2l-labs-oufilter-demo-page>
+```
+
+### General Usage
+
+```js
+import { action, decorate, observable } from 'mobx';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { OuFilterDataManager } from '@brightspace-ui-labs/ou-filter/ou-filter.js';
+
+class FooDataManager extends OuFilterDataManager {
+
+	constructor() {
+		super();
+		this._orgUnitTree = new Tree({});
+	}
+
+	async loadData() {
+		this._orgUnitTree = new Tree({ nodes: ..., ... });
+	}
+}
+
+decorate(FooDataManager, {
+	_orgUnitTree: observable,
+	loadData: action
+});
+
+class FooPage extends MobxLitElement {
+  constructor() {
+    this.dataManager = new FooDataManager();
+  }
+
+  firstUpdated() {
+    this.dataManager.loadData();
+  }
+
+  render () {
+    return html`
+      <d2l-labs-ou-filter
+        .dataManager=${this.dataManager}
+        select-all-ui
+        @d2l-labs-ou-filter-change="${this._orgUnitFilterChange}"
+      ></d2l-labs-ou-filter>`;
+  }
+
+  _orgUnitFilterChange() {
+    console.log(event.target.selected);
+  }
+}
+```
+
+<!-- docs: start hidden content -->
+
+**Properties:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| dataManager | Object | {empty} | Object that extends OuFilterDataManager. It provides and manages data for d2l-labs-ou-filter |
+| select-all-ui | Boolean | {empty} | Shows Select all button |
+| d2l-labs-ou-filter-change | Function | {empty} | Event handler that is fired when selection is changed |
+| disabled | Boolean | {empty} | Render the filter in a disabled state |
+
+<!-- docs: end hidden content -->

--- a/src/components/wizard/README.md
+++ b/src/components/wizard/README.md
@@ -1,34 +1,52 @@
 # Wizard
 
-The `<d2l-labs-wizard>` can be used to be display a stepped workflow.
+The wizard component can be used to display a stepped workflow.
 
-## Usage
+## Wizard [d2l-labs-wizard]
 
+<!-- docs: demo code -->
 ```html
 <script type="module">
-    import '@brightspace-ui/labs/components/wizard.js';
-	import '@brightspace-ui/labs/components/wizard-step.js';
+  import '@brightspace-ui/labs/components/wizard.js';
+  import '@brightspace-ui/labs/components/wizard-step.js';
+  // <!-- docs: start hidden content -->
+  requestAnimationFrame(() => {
+    const wizard = document.getElementById('wizard');
+    wizard.addEventListener('stepper-next', function() {
+      wizard.next();
+    });
+    wizard.addEventListener('stepper-restart', function() {
+      wizard.restart();
+    });
+  })
+  // <!-- docs: end hidden content -->
 </script>
-<d2l-labs-wizard id="wizard">
-	<d2l-labs-wizard-step step-title="Step 1">
-		<p> First step </p>
-	</d2l-labs-wizard-step>
+<d2l-labs-wizard
+  id="wizard"
+  selected-step="1">
+  <d2l-labs-wizard-step
+    next-button-aria-label="Go to step 2"
+    step-title="Get Started"
+    hide-restart-button="true">
+    <p>First Step</p>
+  </d2l-labs-wizard-step>
 
-	<d2l-labs-wizard-step step-title="Step 2">
-		<p> Second step </p>
-	</d2l-labs-wizard-step>
+  <d2l-labs-wizard-step
+    aria-title="This is the second step"
+    restart-button-tooltip="Restart this wizard">
+    <p>Second Step</p>
+  </d2l-labs-wizard-step>
+
+  <d2l-labs-wizard-step
+    step-title="Almost Done"
+    next-button-title="Done"
+    next-button-tooltip="Save this wizard">
+    <p>Last Step</p>
+  </d2l-labs-wizard-step>
 </d2l-labs-wizard>
-<script>
-	var wizard = document.getElementById('wizard');
-	wizard.addEventListener('stepper-next', function() {
-		wizard.next();
-	});
-	wizard.addEventListener('stepper-restart', function() {
-		wizard.restart();
-	});
-</script>
 ```
 
+<!-- docs: start hidden content -->
 
 ### Properties:
 
@@ -47,3 +65,4 @@ The `<d2l-labs-wizard>` can be used to be display a stepped workflow.
 - `stepper-next`: dispatched when the Next button is clicked
 - `stepper-restart`: dispatched when the Restart button is clicked
 
+<!-- docs: end hidden content -->


### PR DESCRIPTION
This cleans up the `wizard` README and adds the `ou-filter` README (I'm guessing this was just missed in the migration?).

I tried to get `ou-filter` to work with a simple demo in the docs site, but because of the use of mobx we'd have to load it in ways that felt awkward. We probably need to figure out how we want to handle demos of data-heavy components that may need to be wrapped - this will also come up with the `lms-core` stuff. For now, I'm just going to expose the demo component and use it there.