### PR TITLE
GAUD-8069: add flag to disable route order fix

### DIFF
--- a/src/utilities/router/router.js
+++ b/src/utilities/router/router.js
@@ -38,10 +38,11 @@ const _handleRouteView = (context, next, r) => {
 };
 
 const _handleRouteLoader = r => (context, next) => {
+	const disableRouteOrderFix = _lastOptions?.disableRouteOrderFix ?? false;
 	const enableRouteOrderFix = _lastOptions?.enableRouteOrderFix ?? false;
 
 	// Skip further pattern matches if the route has already been handled
-	if (enableRouteOrderFix && context.handled) {
+	if (!disableRouteOrderFix && enableRouteOrderFix && context.handled) {
 		next();
 		return;
 	}
@@ -51,7 +52,7 @@ const _handleRouteLoader = r => (context, next) => {
 			_handleRouteView(context, next, r);
 		});
 	} else if (r.pattern && r.to) {
-		if (enableRouteOrderFix) {
+		if (!disableRouteOrderFix && enableRouteOrderFix) {
 			activePage.redirect(r.to);
 		} else {
 			activePage.redirect(r.pattern, r.to);

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -55,7 +55,11 @@ const initRouter = () => {
 			load1,
 			load2,
 		],
-		{ hashbang: true, customPage: true }
+		{
+			enableRouteOrderFix: true,
+			hashbang: true,
+			customPage: true
+		}
 	);
 };
 


### PR DESCRIPTION
We'd prefer that the route order fix be applied by default so that consumers don't need to worry about it, we don't need to warn them about it and we can generally move on with our lives. 😆 

I'm going to do this in 4 phases:
1. Introduce `disableRouteOrderFix`. When set to `true`, the fix won't be applied.
2. Update consumers that aren't currently setting `enableRouteOrderFix` to pass `disableRouteOrderFix`.
3. Remove the concept of a `enableRouteOrderFix` option, so the fix will be enabled by default.
4. Update consumers that were sending `enableRouteOrderFix` to no longer pass it.