### PR TITLE
GAUD-8160: remove enablerRouteOrderFix option

### DIFF
--- a/demo/utilities/router/route-loader.js
+++ b/demo/utilities/router/route-loader.js
@@ -23,7 +23,6 @@ registerRoutes(
 		}
 	],
 	{
-		basePath: basePath,
-		enableRouteOrderFix: true
+		basePath: basePath
 	}
 );

--- a/src/utilities/router/README.md
+++ b/src/utilities/router/README.md
@@ -222,31 +222,6 @@ describe('Page Routing', () => {
 
 ### Route order inversion issue
 
-There's currently an issue with the way registered routes are processed that can cause the order of matching to appear to be inverted. This is not noticeable in many cases since it's often the case that only a single route will match regardless of the order. This does however come up when dealing with wildcard (`*`) routes (e.g. 404 redirect routes).
+This issue is resolved by default but the fix can be bypassed (for backwards compatibility) by setting the `disableRouteOrderFix` option to `true`.
 
-If you notice that you have to put any routes with wildcards (`*`) before those without instead of after, this is the reason why.
-
-#### Issue Fix
-
-There is currently a fix available for this ordering issue, but it requires setting the `enableRouteOrderFix` option to `true`. Ex:
-
-```js
-registerRoutes([
-  {
-    pattern: '/home',
-    view: () => html`...`
-  },
-  {
-    pattern: '/404',
-    view: () => html`...`
-  },
-  {
-    pattern: '*',
-    to: '/404'
-  }
-], {
-  enableRouteOrderFix: true
-});
-```
-
-Note: The reason this is an opt-in fix is that a lot of existing implementations of lit-router have worked around this issue by putting the wildcard routes at the start, which would break if the issue were fixed for everyone automatically.
+Bypassing the fix causes a warning to appear in the dev console. To resolve the warning, remove the `disaableRouteOrderFix` option and thoroughly test your routing. If your routes contain wildcards (`*`, typically for 404s), you may need to register them last.

--- a/src/utilities/router/router.js
+++ b/src/utilities/router/router.js
@@ -39,10 +39,9 @@ const _handleRouteView = (context, next, r) => {
 
 const _handleRouteLoader = r => (context, next) => {
 	const disableRouteOrderFix = _lastOptions?.disableRouteOrderFix ?? false;
-	const enableRouteOrderFix = _lastOptions?.enableRouteOrderFix ?? false;
 
 	// Skip further pattern matches if the route has already been handled
-	if (!disableRouteOrderFix && enableRouteOrderFix && context.handled) {
+	if (!disableRouteOrderFix && context.handled) {
 		next();
 		return;
 	}
@@ -52,7 +51,7 @@ const _handleRouteLoader = r => (context, next) => {
 			_handleRouteView(context, next, r);
 		});
 	} else if (r.pattern && r.to) {
-		if (!disableRouteOrderFix && enableRouteOrderFix) {
+		if (!disableRouteOrderFix) {
 			activePage.redirect(r.to);
 		} else {
 			activePage.redirect(r.pattern, r.to);
@@ -94,7 +93,7 @@ export const registerRoutes = (routes, options) => {
 	if (hasRegistered) throw new Error('May not construct multiple routers.');
 	hasRegistered = true;
 
-	if (!options?.enableRouteOrderFix) console.warn('lit-router: The enableRouteOrderFix option is not enabled. This may cause issues with route handling. See here for details: https://github.com/BrightspaceUI/labs/tree/main/src/utilities/router#route-order-inversion-issue');
+	if (options?.disableRouteOrderFix) console.warn('lit-router: The disableRouteOrderFix option is enabled, which may cause issues with route handling. See here for details: https://github.com/BrightspaceUI/labs/tree/main/src/utilities/router#route-order-inversion-issue');
 
 	configure(options);
 

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -56,7 +56,6 @@ const initRouter = () => {
 			load2,
 		],
 		{
-			enableRouteOrderFix: true,
 			hashbang: true,
 			customPage: true
 		}


### PR DESCRIPTION
We'd prefer that the route order fix be applied by default so that consumers don't need to worry about it, we don't need to warn them about it and we can generally move on with our lives. 😆 

I'm going to do this in 4 phases:
1. Introduce `disableRouteOrderFix` (complete ✅ ). When set to `true`, the fix won't be applied. It defaults to `false`.
2. Update consumers that aren't currently setting `enableRouteOrderFix` to pass `disableRouteOrderFix` (complete ✅ ).
3. Remove the concept of a `enableRouteOrderFix` option, so the fix will be enabled by default (this PR)
4. Update consumers that were sending `enableRouteOrderFix` to no longer pass it.