### PR TITLE
GAUD-8027: non-breaking attribute changes

### DIFF
--- a/demo/components/grade-result/index.html
+++ b/demo/components/grade-result/index.html
@@ -64,6 +64,8 @@
 						scoreDenominator="20"
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
 					></d2l-labs-grade-result-presentational>
@@ -106,6 +108,8 @@
 						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"symbol":"-"}'
 					></d2l-labs-grade-result-presentational>
@@ -167,6 +171,8 @@
 						scoreDenominator="20"
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						readOnly
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
@@ -212,6 +218,8 @@
 						selectedLetterGrade="2"
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						readOnly
 						display-student-grade-preview
 						student-grade-preview='{"symbol":"-"}'
@@ -264,6 +272,8 @@
 						isManualOverrideActive
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -311,6 +321,8 @@
 						isManualOverrideActive
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -357,6 +369,8 @@
 						readOnly
 						includeGradeButton
 						includeReportsButton
+						gradeButtonTooltip="Assignment 1 Grade Item Attached"
+						reportsButtonTooltip="Class and user statistics"
 						subtitleText="Average post score"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'>

--- a/src/components/grade-result/grade-result-letter-score.js
+++ b/src/components/grade-result/grade-result-letter-score.js
@@ -12,7 +12,7 @@ export class D2LGradeResultLetterScore extends LocalizeLabsElement(LitElement) {
 		return {
 			availableOptions: { type: Object },
 			label: { type: String },
-			selectedOption: { type: String },
+			selectedOption: { attribute: 'selected-option', type: String },
 			readOnly: { type: Boolean }
 		};
 	}

--- a/src/components/grade-result/grade-result-numeric-score.js
+++ b/src/components/grade-result/grade-result-numeric-score.js
@@ -21,12 +21,12 @@ export class D2LGradeResultNumericScore extends LocalizeLabsElement(LitElement) 
 	static get properties() {
 		return {
 			label: { type: String },
-			scoreNumerator: { type: Number, converter: numberConverter },
-			scoreDenominator: { type: Number },
+			scoreNumerator: { attribute: 'score-numerator', type: Number, converter: numberConverter },
+			scoreDenominator: { attribute: 'score-denominator', type: Number },
 			readOnly: { type: Boolean },
 			required: { type: Boolean },
-			allowNegativeScore: { type: Boolean },
-			showFlooredScoreWarning: { type: Boolean },
+			allowNegativeScore: { attribute: 'allow-negative-score', type: Boolean },
+			showFlooredScoreWarning: { attribute: 'show-floored-score-warning', type: Boolean },
 		};
 	}
 

--- a/src/components/grade-result/grade-result-presentational.js
+++ b/src/components/grade-result/grade-result-presentational.js
@@ -191,10 +191,6 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 		`;
 	}
 
-	_isReadOnly() {
-		return Boolean(this.readOnly);
-	}
-
 	_onGradeButtonClick() {
 		this.dispatchEvent(new CustomEvent('d2l-grade-result-grade-button-click', {
 			bubbles: true,
@@ -248,9 +244,9 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 		return html`
 			<d2l-labs-grade-result-letter-score
 				.availableOptions=${this.letterGradeOptions}
-				.label=${this.inputLabelText}
-				.readOnly=${this._isReadOnly()}
-				.selectedOption=${this.selectedLetterGrade}
+				label=${this.inputLabelText}
+				?readonly=${this.readOnly}
+				selected-option=${ifDefined(this.selectedLetterGrade)}
 			></d2l-labs-grade-result-letter-score>
 		`;
 	}
@@ -275,13 +271,13 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 	_renderNumericScoreComponent() {
 		return html`
 			<d2l-labs-grade-result-numeric-score
-				?allowNegativeScore=${this.allowNegativeScore}
-				.label=${this.inputLabelText}
-				.readOnly=${this._isReadOnly()}
+				?allow-negative-score=${this.allowNegativeScore}
+				label=${this.inputLabelText}
+				?readonly=${this.readOnly}
 				?required=${this.required}
-				.scoreDenominator=${this.scoreDenominator}
-				.scoreNumerator=${this.scoreNumerator}
-				?showFlooredScoreWarning=${this.showFlooredScoreWarning}
+				score-denominator=${ifDefined(this.scoreDenominator)}
+				score-numerator=${ifDefined(this.scoreNumerator)}
+				?show-floored-score-warning=${this.showFlooredScoreWarning}
 			></d2l-labs-grade-result-numeric-score>
 		`;
 	}


### PR DESCRIPTION
Many of the `<d2l-labs-grade-result-*>` components don't adhere to our kebab-case guidance for multi-word attributes, and we want to resolve that.

This change is going to happen in 3 stages:
1. Go through consumers of the components and add both kebab-case and non-kebab-case attributes
2. Switch the `<d2l-labs-grade-result-*>` components to only support kebab-case
3. Go back through consumers and remove the non-kebab-case attributes

But this PR is none of those! This is just making some fixes that can be safely done ahead of time as these components aren't directly referenced by consumers.