### PR TITLE
GAUD-8027: switch to kebab-case attributes

### DIFF
--- a/demo/components/grade-result/index.html
+++ b/demo/components/grade-result/index.html
@@ -33,11 +33,11 @@
 				<h6>number grade, no icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						labelHeadingLevel="3"
-						scoreNumerator="5"
-						scoreDenominator="20"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						label-heading-level="3"
+						score-numerator="5"
+						score-denominator="20"
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
 					></d2l-labs-grade-result-presentational>
@@ -46,10 +46,10 @@
 				<h6>number grade with decimal, no icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="1.5555555"
-						scoreDenominator="5"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="1.5555555"
+						score-denominator="5"
 						display-student-grade-preview
 						student-grade-preview='{"score":1.56, "symbol":"Bad", "colour":"#FF0000"}'
 					></d2l-labs-grade-result-presentational>
@@ -58,14 +58,14 @@
 				<h6>number grade, icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
 					></d2l-labs-grade-result-presentational>
@@ -74,14 +74,14 @@
 				<h6>number grade, icons, tooltips</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="10"
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="10"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
 					></d2l-labs-grade-result-presentational>
@@ -90,11 +90,11 @@
 				<h6>letter grade, no icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
-						scoreDenominator="5"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letter-grade="2"
+						score-denominator="5"
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"B", "colour":"#00FF00"}'
 					></d2l-labs-grade-result-presentational>
@@ -103,13 +103,13 @@
 				<h6>letter grade, icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"symbol":"-"}'
 					></d2l-labs-grade-result-presentational>
@@ -118,13 +118,13 @@
 				<h6>letter grade, icons, tooltips</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"symbol":"- %"}'
 					></d2l-labs-grade-result-presentational>
@@ -139,10 +139,10 @@
 				<h6>number grade, no icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
@@ -152,10 +152,10 @@
 				<h6>number grade with decimals, no icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="1.555555"
-						scoreDenominator="20"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="1.555555"
+						score-denominator="20"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"score":1.56, "symbol":"Bad", "colour":"#FF0000"}'
@@ -165,14 +165,14 @@
 				<h6>number grade, icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
@@ -182,14 +182,14 @@
 				<h6>number grade, icons, tooltips</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"Fine", "colour":"#FFCC00"}'
@@ -199,10 +199,10 @@
 				<h6>letter grade, no icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letter-grade="2"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"score":5, "symbol":"B", "colour":"#00FF00"}'
@@ -212,14 +212,14 @@
 				<h6>letter grade, icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letter-grade="2"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"symbol":"-"}'
@@ -229,14 +229,14 @@
 				<h6>letter grade, icons, tooltips</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letter-grade="2"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						readonly
 						display-student-grade-preview
 						student-grade-preview='{"symbol":"- %"}'
@@ -252,28 +252,28 @@
 				<h6>number grade, no icons, clear manual override option</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
-						isGradeAutoCompleted
-						isManualOverrideActive
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						is-grade-auto-completed
+						is-manual-override-active
 					></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 				<h6>number grade, icons, clear manual override option</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
-						isGradeAutoCompleted
-						isManualOverrideActive
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						is-grade-auto-completed
+						is-manual-override-active
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -282,16 +282,16 @@
 				<h6>number grade, icons, tooltips, clear manual override option</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
-						isGradeAutoCompleted
-						isManualOverrideActive
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						is-grade-auto-completed
+						is-manual-override-active
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -301,28 +301,27 @@
 				<h6>letter grade, no icons, clear manual override option</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
-						isGradeAutoCompleted
-						isManualOverrideActive
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letter-grade="2"
+						is-manual-override-active
 					></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 				<h6>letter grade, icons, clear manual override option</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
-						isGradeAutoCompleted
-						isManualOverrideActive
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letterGrade="2"
+						is-grade-auto-completed
+						is-manual-override-active
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -331,16 +330,16 @@
 				<h6>letter grade, icons, tooltips, clear manual override option</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="LetterGrade"
-						labelText="Overall Grade"
-						letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-						selectedLetterGrade="2"
-						isGradeAutoCompleted
-						isManualOverrideActive
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="LetterGrade"
+						label-text="Overall Grade"
+						letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+						selected-letter-grade="2"
+						is-grade-auto-completed
+						is-manual-override-active
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -352,7 +351,13 @@
 
 				<h6>Custom manual override clear text</h6>
 				<d2l-demo-snippet>
-					<d2l-labs-grade-result-presentational gradeType="Numeric" labelText="Overall Grade" scoreNumerator="5" scoreDenominator="20" isGradeAutoCompleted isManualOverrideActive customManualOverrideClearText="Substituted Override Clear Text"></d2l-labs-grade-result-presentational>
+					<d2l-labs-grade-result-presentational
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						is-manual-override-active
+						custom-manual-override-clear-text="Substituted Override Clear Text"></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 			</div>
@@ -362,16 +367,16 @@
 				<h6>Show grade calculation method</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Overall Grade"
-						scoreNumerator="5"
-						scoreDenominator="20"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
 						readonly
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Assignment 1 Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
-						subtitleText="Average post score"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Assignment 1 Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
+						subtitle-text="Average post score"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'>
 					</d2l-labs-grade-result-presentational>
@@ -383,7 +388,11 @@
 
 				<h6>Dynamic Width</h6>
 				<d2l-demo-snippet>
-					<d2l-labs-grade-result-presentational gradeType="Numeric" labelText="Overall Grade" scoreNumerator="33333333" scoreDenominator="33333333"></d2l-labs-grade-result-presentational>
+					<d2l-labs-grade-result-presentational
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="33333333"
+						score-denominator="33333333"></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 			</div>
@@ -394,37 +403,37 @@
 				<h6>Negative marking enabled (for question scores)</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Score"
-						scoreNumerator="-1"
-						scoreDenominator="3"
-						allowNegativeScore
+						grade-type="Numeric"
+						label-text="Score"
+						score-numerator="-1"
+						score-denominator="3"
+						allow-negative-score
 					></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 				<h6>Floored negative score hint (for attempt scores)</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Attempt Grade"
-						scoreNumerator="0"
-						scoreDenominator="20"
-						showFlooredScoreWarning
+						grade-type="Numeric"
+						label-text="Attempt Grade"
+						score-numerator="0"
+						score-denominator="20"
+						show-floored-score-warning
 					></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 				<h6>Floored negative score hint, icons (for attempt scores on quizzes with grade items)</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Attempt Grade"
-						scoreNumerator="0"
-						scoreDenominator="20"
-						showFlooredScoreWarning
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Example Quiz Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						grade-type="Numeric"
+						label-text="Attempt Grade"
+						score-numerator="0"
+						score-denominator="20"
+						show-floored-score-warning
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Example Quiz Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -433,11 +442,11 @@
 				<h6>Floored negative score hint, read-only</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Attempt Grade"
-						scoreNumerator="0"
-						scoreDenominator="20"
-						showFlooredScoreWarning
+						grade-type="Numeric"
+						label-text="Attempt Grade"
+						score-numerator="0"
+						score-denominator="20"
+						show-floored-score-warning
 						readonly
 					></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
@@ -445,16 +454,16 @@
 				<h6>Floored negative score hint, read-only, icons</h6>
 				<d2l-demo-snippet>
 					<d2l-labs-grade-result-presentational
-						gradeType="Numeric"
-						labelText="Attempt Grade"
-						scoreNumerator="0"
-						scoreDenominator="20"
-						showFlooredScoreWarning
+						grade-type="Numeric"
+						label-text="Attempt Grade"
+						score-numerator="0"
+						score-denominator="20"
+						show-floored-score-warning
 						readonly
-						includeGradeButton
-						includeReportsButton
-						gradeButtonTooltip="Example Quiz Grade Item Attached"
-						reportsButtonTooltip="Class and user statistics"
+						include-grade-button
+						include-reports-button
+						grade-button-tooltip="Example Quiz Grade Item Attached"
+						reports-button-tooltip="Class and user statistics"
 						display-student-grade-preview
 						student-grade-preview='{"score":10, "symbol":"Very Good", "colour":"#00FFFF"}'
 					></d2l-labs-grade-result-presentational>
@@ -466,12 +475,22 @@
 
 				<h6>Required validation error</h6>
 				<d2l-demo-snippet>
-					<d2l-labs-grade-result-presentational inputLabelText="Overall grade" gradeType="Numeric" labelText="Overall Grade" scoreNumerator="undefined" scoreDenominator="20" required></d2l-labs-grade-result-presentational>
+					<d2l-labs-grade-result-presentational
+						input-label-text="Overall grade"
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="undefined"
+						score-denominator="20"
+						required></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 				<h6>Number range validation error</h6>
 				<d2l-demo-snippet>
-					<d2l-labs-grade-result-presentational gradeType="Numeric" labelText="Overall Grade" scoreNumerator="-1" scoreDenominator="20"></d2l-labs-grade-result-presentational>
+					<d2l-labs-grade-result-presentational
+					grade-type="Numeric"
+					label-text="Overall Grade"
+					score-numerator="-1"
+					score-denominator="20"></d2l-labs-grade-result-presentational>
 				</d2l-demo-snippet>
 
 			</div>

--- a/src/components/grade-result/README.md
+++ b/src/components/grade-result/README.md
@@ -10,11 +10,11 @@ Components used for rendering grades in Brightspace.
   import '@brightspace-ui/labs/components/grade-result/grade-result-presentational.js';
 </script>
 <d2l-labs-grade-result-presentational
-  gradeType="Numeric"
-  labelText="Overall Grade"
-  labelHeadingLevel="3"
-  scoreNumerator="5"
-  scoreDenominator="20"
+  grade-type="Numeric"
+  label-text="Overall Grade"
+  label-heading-level="3"
+  score-numerator="5"
+  score-denominator="20"
   display-student-grade-preview
   student-grade-preview='{"score": 5, "symbol": "Fine", "colour": "#FFCC00"}'
 ></d2l-labs-grade-result-presentational>
@@ -26,16 +26,16 @@ Components used for rendering grades in Brightspace.
   import '@brightspace-ui/labs/components/grade-result/grade-result-presentational.js';
 </script>
 <d2l-labs-grade-result-presentational
-  gradeType="LetterGrade"
-  labelText="Overall Grade"
-  letterGradeOptions='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
-  selectedLetterGrade="2"
-  scoreDenominator="20"
-  isManualOverrideActive
-  includeGradeButton
-  gradeButtonTooltip="Assignment 1 Grade Item Attached"
-  includeReportsButton
-  reportsButtonTooltip="Class and user statistics"
+  grade-type="LetterGrade"
+  label-text="Overall Grade"
+  letter-grade-options='{ "0": { "LetterGrade": "None", "PercentStart": null}, "1": { "LetterGrade": "A", "PercentStart": "75"}, "2": { "LetterGrade": "B", "PercentStart": "50"}}'
+  selected-letter-grade="2"
+  score-denominator="20"
+  is-manual-override-active
+  include-grade-button
+  grade-button-tooltip="Assignment 1 Grade Item Attached"
+  include-reports-button
+  reports-button-tooltip="Class and user statistics"
   display-student-grade-preview
   student-grade-preview='{"score": 10, "symbol": "Very Good", "colour": "#00FFFF"}'
 ></d2l-labs-grade-result-presentational>
@@ -47,25 +47,25 @@ Components used for rendering grades in Brightspace.
 
 | Property                          | GradeType      | Type                        | Default     | Description                                                  |
 | ----------------------------------| -------------- | --------------------------- | ----------- | ------------------------------------------------------------ |
-| `gradeType`                       | All            | `string ('Numeric' or 'LetterGrade')` | `'Numeric'` | Specifies the type of grade that the component is meant to render. |
-| `labelText`                       | All            | `string`                    | `''`        | The text that appears above the component.                   |
-| `scoreNumerator`                  | Numeric        | `number`                    | `0`         | The numerator of the numeric score that is given.            |
-| `scoreDenominator`                | Numeric        | `number`                    | `0`         | The denominator of the numeric score that is given.          |
-| `selectedLetterGrade`             | LetterGrade    | `string`                    | `''`        | The current selected letter grade of the options given.      |
-| `letterGradeOptions`              | LetterGrade    | `Object`                    | `null`      | A dictionary where the key is a unique id and the value is an object containing the LetterGrade text and the PercentStart. |
-| `includeGradeButton`              | All            | `boolean`                   | `false`     | Determines whether the grades icon button is rendered.       |
-| `includeReportsButton`            | All            | `boolean`                   | `false`     | Determines whether the reports icon button is rendered.      |
-| `gradeButtonTooltip`              | All            | `string`                    | `''`        | The text that is inside of the tooltip when hovering over the grades button. |
-| `reportsButtonTooltip`            | All            | `string`                    | `''`        | The text that is inside of the tooltip when hovering over the reports button. |
+| `grade-type`                       | All            | `string ('Numeric' or 'LetterGrade')` | `'Numeric'` | Specifies the type of grade that the component is meant to render. |
+| `label-text`                       | All            | `string`                    | `''`        | The text that appears above the component.                   |
+| `score-numerator`                  | Numeric        | `number`                    | `0`         | The numerator of the numeric score that is given.            |
+| `score-denominator`                | Numeric        | `number`                    | `0`         | The denominator of the numeric score that is given.          |
+| `selected-letter-grade`             | LetterGrade    | `string`                    | `''`        | The current selected letter grade of the options given.      |
+| `letter-grade-options`              | LetterGrade    | `Object`                    | `null`      | A dictionary where the key is a unique id and the value is an object containing the LetterGrade text and the PercentStart. |
+| `include-grade-button`              | All            | `boolean`                   | `false`     | Determines whether the grades icon button is rendered.       |
+| `include-reports-button`            | All            | `boolean`                   | `false`     | Determines whether the reports icon button is rendered.      |
+| `grade-button-tooltip`              | All            | `string`                    | `''`        | The text that is inside of the tooltip when hovering over the grades button. |
+| `reports-button-tooltip`            | All            | `string`                    | `''`        | The text that is inside of the tooltip when hovering over the reports button. |
 | `readonly`                        | All            | `boolean`                   | `false`     | Set to `true` if the user does not have permissions to edit the grade. |
-| `isManualOverrideActive`          | All            | `boolean`                   | `false`     | Set to `true` if the user is currently manually overriding the grade. This will display the button to 'Clear Manual Override'. |
-| `hideTitle`                       | All            | `boolean`                   | `false`     | This property will hide the "Overall Grade" title above the component. |
-| `customManualOverrideClearText`   | All            | `string`                    | `undefined` | This property will substitute the stock text on the "Clear Manual Override" button. |
-| `subtitleText`                    | All            | `string`                    | `undefined` | This property will show the given text under the title. |
+| `is-manual-override-active`          | All            | `boolean`                   | `false`     | Set to `true` if the user is currently manually overriding the grade. This will display the button to 'Clear Manual Override'. |
+| `hide-title`                       | All            | `boolean`                   | `false`     | This property will hide the "Overall Grade" title above the component. |
+| `custom-manual-override-clear-text`   | All            | `string`                    | `undefined` | This property will substitute the stock text on the "Clear Manual Override" button. |
+| `subtitle-text`                    | All            | `string`                    | `undefined` | This property will show the given text under the title. |
 | `required`                 | Numeric        | `Boolean`                    | `false` | Set to `true` if an undefined/blank grade is not considered valid |
-| `inputLabelText`                 | Numeric        | `string`                    | `''` |  This property sets the label that will be used inside the aria-label and validation error tool-tips |
-| `allowNegativeScore`             | Numeric        | `boolean`                    | `'false'`   | Set to `true` if negative scores can be entered                         |
-| `showFlooredScoreWarning`        | Numeric        | `boolean`                    | `'false'`   | Set to `true` if displaying a negative grade that has been floored at 0 |
+| `input-label-text`                 | Numeric        | `string`                    | `''` |  This property sets the label that will be used inside the aria-label and validation error tool-tips |
+| `allow-negative-score`             | Numeric        | `boolean`                    | `'false'`   | Set to `true` if negative scores can be entered                         |
+| `show-floored-score-warning`        | Numeric        | `boolean`                    | `'false'`   | Set to `true` if displaying a negative grade that has been floored at 0 |
 
 ### Events
 

--- a/src/components/grade-result/grade-result-icon-button.js
+++ b/src/components/grade-result/grade-result-icon-button.js
@@ -7,25 +7,21 @@ export class D2LGradeResultIconButton extends LitElement {
 		return {
 			text: { type: String },
 			icon: { type: String },
-			_id: { type: String },
 		};
-	}
-
-	constructor() {
-		super();
-		this._id = getUniqueId();
 	}
 
 	render() {
 		return html`
 			<d2l-button-icon
-				id="d2l-grade-result-icon-button-${this._id}"
+				id="d2l-grade-result-icon-button-${this.#id}"
 				icon="${this.icon}"
 				@click="${this._onClick}"
 				text="${this.text}"
 			></d2l-button-icon>
 		`;
 	}
+
+	#id = getUniqueId();
 
 	_onClick() {
 		this.dispatchEvent(new CustomEvent('d2l-grade-result-icon-button-click', {

--- a/src/components/grade-result/grade-result-letter-score.js
+++ b/src/components/grade-result/grade-result-letter-score.js
@@ -10,7 +10,7 @@ export class D2LGradeResultLetterScore extends LocalizeLabsElement(LitElement) {
 
 	static get properties() {
 		return {
-			availableOptions: { type: Object },
+			availableOptions: { attribute: 'available-options', type: Object },
 			label: { type: String },
 			selectedOption: { attribute: 'selected-option', type: String },
 			readonly: { type: Boolean }

--- a/src/components/grade-result/grade-result-presentational.js
+++ b/src/components/grade-result/grade-result-presentational.js
@@ -26,12 +26,12 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 			 * Set to true if negative scores can be entered
 			 * @type {boolean}
 			 */
-			allowNegativeScore: { type: Boolean },
+			allowNegativeScore: { attribute: 'allow-negative-score', type: Boolean },
 			/**
 			 * This property will substitute the stock text on the "Clear Manual Override" button
 			 * @type {string}
 			 */
-			customManualOverrideClearText: { type: String },
+			customManualOverrideClearText: { attribute: 'custom-manual-override-clear-text', type: String },
 			/**
 			 * @type {boolean}
 			 */
@@ -40,51 +40,51 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 			 * The text that is inside of the tooltip when hovering over the grades button
 			 * @type {string}
 			 */
-			gradeButtonTooltip: { type: String },
+			gradeButtonTooltip: { attribute: 'grade-button-tooltip', type: String },
 			/**
 			 * Specifies the type of grade that the component is meant to render
 			 * @type {'Numeric'|'LetterGrade'}
 			 */
-			gradeType: { type: String },
+			gradeType: { attribute: 'grade-type', type: String },
 			/**
 			 * This property will hide the "Overall Grade" title above the component
 			 * @type {boolean}
 			 */
-			hideTitle: { type: Boolean },
+			hideTitle: { attribute: 'hide-title', type: Boolean },
 			/**
 			 * Determines whether the grades icon button is rendered
 			 * @type {boolean}
 			 */
-			includeGradeButton: { type: Boolean },
+			includeGradeButton: { attribute: 'include-grade-button', type: Boolean },
 			/**
 			 * Determines whether the reports icon button is rendered
 			 * @type {boolean}
 			 */
-			includeReportsButton: { type: Boolean },
+			includeReportsButton: { attribute: 'include-reports-button', type: Boolean },
 			/**
 			 * This property sets the label that will be used inside the aria-label and validation error tooltips
 			 * @type {string}
 			 */
-			inputLabelText: { type: String },
+			inputLabelText: { attribute: 'input-label-text', type: String },
 			/**
 			 * Set to true if the user is currently manually overriding the grade. This will display the button to 'Clear Manual Override'.
 			 * @type {boolean}
 			 */
-			isManualOverrideActive: { type: Boolean },
+			isManualOverrideActive: { attribute: 'is-manual-override-active', type: Boolean },
 			/**
 			 * @type {number}
 			 */
-			labelHeadingLevel: { type: Number },
+			labelHeadingLevel: { attribute: 'label-heading-level', type: Number },
 			/**
 			 * The text that appears above the component
 			 * @type {string}
 			 */
-			labelText: { type: String },
+			labelText: { attribute: 'label-text', type: String },
 			/**
 			 * A dictionary where the key is a unique id and the value is an object containing the LetterGrade text and the PercentStart
 			 * @type {object}
 			 */
-			letterGradeOptions: { type: Object },
+			letterGradeOptions: { attribute: 'letter-grade-options', type: Object },
 			/**
 			 * Set to true if the user does not have permissions to edit the grade
 			 * @type {boolean}
@@ -94,7 +94,7 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 			 * The text that is inside of the tooltip when hovering over the reports button
 			 * @type {string}
 			 */
-			reportsButtonTooltip: { type: String },
+			reportsButtonTooltip: { attribute: 'reports-button-tooltip', type: String },
 			/**
 			 * Set to true if an undefined/blank grade is not considered valid
 			 * @type {boolean}
@@ -104,27 +104,27 @@ export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement
 			 * The denominator of the numeric score that is given
 			 * @type {number}
 			 */
-			scoreDenominator: { type: Number },
+			scoreDenominator: { attribute: 'score-denominator', type: Number },
 			/**
 			 * The numerator of the numeric score that is given
 			 * @type {number}
 			 */
-			scoreNumerator: { type: Number, converter: numberConverter },
+			scoreNumerator: { attribute: 'score-numerator', type: Number, converter: numberConverter },
 			/**
 			 * The current selected letter grade of the options given
 			 * @type {string}
 			 */
-			selectedLetterGrade: { type: String },
+			selectedLetterGrade: { attribute: 'selected-letter-grade', type: String },
 			/**
 			 * Set to true if displaying a negative grade that has been floored at 0
 			 * @type {boolean}
 			 */
-			showFlooredScoreWarning: { type: Boolean },
+			showFlooredScoreWarning: { attribute: 'show-floored-score-warning', type: Boolean },
 			/**
 			 * This property will show the given text under the title
 			 * @type {string}
 			 */
-			subtitleText: { type: String },
+			subtitleText: { attribute: 'subtitle-text', type: String },
 			/**
 			 * @type {object}
 			 */

--- a/test/components/grade-result/d2l-grade-result-autograde-provided.vdiff.js
+++ b/test/components/grade-result/d2l-grade-result-autograde-provided.vdiff.js
@@ -1,5 +1,6 @@
 import '../../../src/components/grade-result/grade-result-presentational.js';
 import { fixture, html } from '@brightspace-ui/testing';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { testDiff } from './vdiff-utils.js';
 
 describe('autograde provided visual diff tests', () => {
@@ -93,18 +94,17 @@ describe('autograde provided visual diff tests', () => {
 				html`
 				<div style='margin: 10px 18px; padding: 50px; display: flex; justify-content: center;'>
 					<d2l-labs-grade-result-presentational
-						.gradeType='${test.gradeType}'
-						.labelText='${test.labelText}'
-						.scoreNumerator=${test.scoreNumerator}
-						.scoreDenominator=${test.scoreDenominator}
-						.gradeButtonTooltip='${test.gradeButtonTooltip}'
-						.reportsButtonTooltip='${test.reportsButtonTooltip}'
-						.letterGradeOptions=${test.letterGradeOptions}
-						.selectedLetterGrade='${test.selectedLetterGrade}'
-						?includeGradeButton=${test.includeGradeButton}
-						?includeReportsButton=${test.includeReportsButton}
-						isManualOverrideActive
-						isGradeAutoCompleted
+						grade-type="${test.gradeType}"
+						label-text="${test.labelText}"
+						score-numerator="${ifDefined(test.scoreNumerator)}"
+						score-denominator="${ifDefined(test.scoreDenominator)}"
+						grade-button-tooltip="${ifDefined(test.gradeButtonTooltip)}"
+						reports-button-tooltip="${ifDefined(test.reportsButtonTooltip)}"
+						.letterGradeOptions="${test.letterGradeOptions}"
+						selected-letter-grade="${ifDefined(test.selectedLetterGrade)}"
+						?include-grade-button="${test.includeGradeButton}"
+						?include-reports-button="${test.includeReportsButton}"
+						is-manual-override-active
 					></d2l-labs-grade-result-presentational>
 				<div>`,
 				{ pagePadding: false }

--- a/test/components/grade-result/d2l-grade-result-custom-manual-override-text.vdiff.js
+++ b/test/components/grade-result/d2l-grade-result-custom-manual-override-text.vdiff.js
@@ -9,13 +9,12 @@ describe('optional override text substitution visual diff tests', () => {
 			html`
 				<div style='margin: 10px 18px; padding: 50px; display: flex; justify-content: center;'>
 					<d2l-labs-grade-result-presentational
-						gradeType='Numeric'
-						labelText='Overall Grade'
-						scoreNumerator=5
-						scoreDenominator=20
-						customManualOverrideClearText='Substituted Override Clear Text'
-						isGradeAutoCompleted
-						isManualOverrideActive
+						grade-type="Numeric"
+						label-text="Overall Grade"
+						score-numerator="5"
+						score-denominator="20"
+						custom-manual-override-clear-text="Substituted Override Clear Text"
+						is-manual-override-active
 					></d2l-labs-grade-result-presentational>
 				<div>`,
 			{ pagePadding: false }

--- a/test/components/grade-result/d2l-grade-result-presentational.test.js
+++ b/test/components/grade-result/d2l-grade-result-presentational.test.js
@@ -11,48 +11,46 @@ const letterGradeOptions = {
 
 const componentManualOverride = html`
 	<d2l-labs-grade-result-presentational
-		gradeType="Numeric"
-		labelText="Overall Grade"
-		scoreNumerator="5"
-		scoreDenominator="20"
-		isGradeAutoCompleted
-		includeGradeButton
-		includeReportsButton
-		gradeButtonTooltip="Assignment 1 Grade Item Attached"
-		reportsButtonTooltip="Class and user statistics"
+		grade-type="Numeric"
+		label-text="Overall Grade"
+		score-numerator="5"
+		score-denominator="20"
+		include-grade-button
+		include-reports-button
+		grade-button-tooltip="Assignment 1 Grade Item Attached"
+		reports-button-tooltip="Class and user statistics"
 	></d2l-labs-grade-result-presentational>
 `;
 
 const componentManualOverrideClear = html`
 	<d2l-labs-grade-result-presentational
-		gradeType="Numeric"
-		labelText="Overall Grade"
-		scoreNumerator="5"
-		scoreDenominator="20"
-		isGradeAutoCompleted
-		isManualOverrideActive
-		includeGradeButton
-		includeReportsButton
-		gradeButtonTooltip="Assignment 1 Grade Item Attached"
-		reportsButtonTooltip="Class and user statistics"
+		grade-type="Numeric"
+		label-text="Overall Grade"
+		score-numerator="5"
+		score-denominator="20"
+		is-manual-override-active
+		include-grade-button
+		include-reports-button
+		grade-button-tooltip="Assignment 1 Grade Item Attached"
+		reports-button-tooltip="Class and user statistics"
 	></d2l-labs-grade-result-presentational>
 `;
 
 const componentNumericScore = html`
 	<d2l-labs-grade-result-presentational
-		gradeType="Numeric"
-		labelText="Overall Grade"
-		scoreNumerator="5"
-		scoreDenominator="20"
+		grade-type="Numeric"
+		label-text="Overall Grade"
+		scorenumerator="5"
+		score-denominator="20"
 	></d2l-labs-grade-result-presentational>
 `;
 
 const componentLetterScore = html`
 	<d2l-labs-grade-result-presentational
-		gradeType="LetterGrade"
-		labelText="Overall Grade"
+		grade-type="LetterGrade"
+		label-text="Overall Grade"
 		.letterGradeOptions=${letterGradeOptions}
-		selectedLetterGrade="C"
+		selected-letter-grade="C"
 	></d2l-labs-grade-result-presentational>
 `;
 
@@ -142,11 +140,11 @@ describe('d2l-grade-result-presentational', () => {
 	it('should treat bounded null numerator as zero when readonly', async() => {
 		const el = await fixture(html`
 			<d2l-labs-grade-result-presentational
-				gradeType="Numeric"
-				labelText="Overall Grade"
+				grade-type="Numeric"
+				label-text="Overall Grade"
 				.scoreNumerator="${null}"
 				readonly
-				scoreDenominator="20">
+				score-denominator="20">
 			</d2l-labs-grade-result-presentational>
 		`);
 		const score = getNumericScore(el).shadowRoot.querySelector('.d2l-grade-result-numeric-score-score-read-only');
@@ -156,10 +154,10 @@ describe('d2l-grade-result-presentational', () => {
 	it('should treat missing numerator as empty string when readonly', async() => {
 		const el = await fixture(html`
 			<d2l-labs-grade-result-presentational
-				gradeType="Numeric"
-				labelText="Overall Grade"
+				grade-type="Numeric"
+				label-text="Overall Grade"
 				readonly
-				scoreDenominator="20">
+				score-denominator="20">
 			</d2l-labs-grade-result-presentational>
 		`);
 		const score = getNumericScore(el).shadowRoot.querySelector('.d2l-grade-result-numeric-score-score-read-only');

--- a/test/components/grade-result/d2l-grade-result-read-only.vdiff.js
+++ b/test/components/grade-result/d2l-grade-result-read-only.vdiff.js
@@ -1,5 +1,6 @@
 import '../../../src/components/grade-result/grade-result-presentational.js';
 import { fixture, html } from '@brightspace-ui/testing';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { testDiff } from './vdiff-utils.js';
 
 describe('read only visual diff tests', () => {
@@ -132,18 +133,18 @@ describe('read only visual diff tests', () => {
 				html`
 				<div style='margin: 10px 18px; padding: 50px; display: flex; justify-content: center;'>
 					<d2l-labs-grade-result-presentational
-						.gradeType='${test.gradeType}'
-						.labelText='${test.labelText}'
-						.scoreNumerator=${test.scoreNumerator}
-						.scoreDenominator=${test.scoreDenominator}
-						.gradeButtonTooltip='${test.gradeButtonTooltip}'
-						.reportsButtonTooltip='${test.reportsButtonTooltip}'
-						.letterGradeOptions=${test.letterGradeOptions}
-						.selectedLetterGrade='${test.selectedLetterGrade}'
-						.subtitleText='${test.subtitleText}'
-						?includeGradeButton=${test.includeGradeButton}
-						?includeReportsButton=${test.includeReportsButton}
-						?showFlooredScoreWarning=${test.showFlooredScoreWarning}
+						grade-type="${test.gradeType}"
+						label-text="${test.labelText}"
+						score-numerator="${ifDefined(test.scoreNumerator)}"
+						score-denominator="${ifDefined(test.scoreDenominator)}"
+						grade-button-tooltip="${ifDefined(test.gradeButtonTooltip)}"
+						reports-tutton-tooltip="${ifDefined(test.reportsButtonTooltip)}"
+						.letterGradeOptions="${test.letterGradeOptions}"
+						selected-letter-grade="${ifDefined(test.selectedLetterGrade)}"
+						subtitle-text="${ifDefined(test.subtitleText)}"
+						?include-grade-button="${test.includeGradeButton}"
+						?include-reports-button="${test.includeReportsButton}"
+						?show-floored-score-warning="${test.showFlooredScoreWarning}"
 						readonly
 					></d2l-labs-grade-result-presentational>
 				<div>`,

--- a/test/components/grade-result/d2l-grade-result-student-grade-preview.vdiff.js
+++ b/test/components/grade-result/d2l-grade-result-student-grade-preview.vdiff.js
@@ -1,6 +1,7 @@
 import '../../../src/components/grade-result/grade-result-student-grade-preview.js';
 import '../../../src/components/grade-result/grade-result-presentational.js';
 import { expect, fixture, html } from '@brightspace-ui/testing';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 describe('student-grade-preview', () => {
 
@@ -176,7 +177,6 @@ describe('presentational-with-grade-preview', () => {
 			labelText: 'Overall Grade',
 			scoreNumerator: '5',
 			scoreDenominator: '20',
-			isGradeAutoCompleted: true,
 			isManualOverrideActive: true,
 			includeGradeButton: true,
 			includeReportsButton: true,
@@ -190,7 +190,6 @@ describe('presentational-with-grade-preview', () => {
 			labelText: 'Overall Grade',
 			scoreNumerator: '5',
 			scoreDenominator: '20',
-			isGradeAutoCompleted: false,
 			isManualOverrideActive: false,
 			includeGradeButton: true,
 			includeReportsButton: true,
@@ -206,7 +205,6 @@ describe('presentational-with-grade-preview', () => {
 			scoreNumerator: '0',
 			scoreDenominator: '20',
 			showFlooredScoreWarning: true,
-			isGradeAutoCompleted: false,
 			isManualOverrideActive: false,
 			includeGradeButton: true,
 			includeReportsButton: true,
@@ -240,21 +238,20 @@ describe('presentational-with-grade-preview', () => {
 					const el = await fixture(
 						html`
 							<d2l-labs-grade-result-presentational
-								?display-student-grade-preview=${test.displayStudentGradePreview}
-								gradeType=${test.gradeType}
-								?includeGradeButton=${test.includeGradeButton}
-								?includeReportsButton=${test.includeReportsButton}
-								?isManualOverrideActive=${test.isManualOverrideActive}
-								?isGradeAutoCompleted=${test.isGradeAutoCompleted}
-								labelText=${test.labelText}
-								letterGradeOptions=${test.letterGradeOptions}
-								?readonly=${test.readonly}
-								scoreDenominator=${test.scoreDenominator}
-								scoreNumerator=${test.scoreNumerator}
-								selectedLetterGrade=${test.selectedLetterGrade}
-								?showFlooredScoreWarning=${test.showFlooredScoreWarning}
-								student-grade-preview=${test.studentGradePreview}
-								subtitleText=${test.subtitleText}
+								?display-student-grade-preview="${test.displayStudentGradePreview}"
+								grade-type="${test.gradeType}"
+								?include-grade-button="${test.includeGradeButton}"
+								?include-reports-button="${test.includeReportsButton}"
+								?is-manual-override-active="${test.isManualOverrideActive}"
+								label-text="${test.labelText}"
+								letter-grade-options="${ifDefined(test.letterGradeOptions)}"
+								?readonly="${test.readonly}"
+								score-denominator="${ifDefined(test.scoreDenominator)}"
+								score-numerator="${ifDefined(test.scoreNumerator)}"
+								selected-letter-grade="${ifDefined(test.selectedLetterGrade)}"
+								?show-floored-score-warning="${test.showFlooredScoreWarning}"
+								student-grade-preview="${test.studentGradePreview}"
+								subtitle-text="${ifDefined(test.subtitleText)}"
 							></d2l-labs-grade-result-presentational>
 						`, { viewport: screenSizeCategory.viewport }
 					);

--- a/test/components/grade-result/d2l-grade-result-write-enabled.vdiff.js
+++ b/test/components/grade-result/d2l-grade-result-write-enabled.vdiff.js
@@ -1,5 +1,6 @@
 import '../../../src/components/grade-result/grade-result-presentational.js';
 import { fixture, html } from '@brightspace-ui/testing';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { testDiff } from './vdiff-utils.js';
 
 describe('write enabled visual diff tests', () => {
@@ -147,18 +148,18 @@ describe('write enabled visual diff tests', () => {
 				html`
 				<div style='margin: 10px 18px; padding: 50px; padding-bottom: 80px; display: flex; justify-content: center;'>
 					<d2l-labs-grade-result-presentational
-						.gradeType='${test.gradeType}'
-						.labelText='${test.labelText}'
-						.scoreNumerator=${test.scoreNumerator}
-						.scoreDenominator=${test.scoreDenominator}
-						.gradeButtonTooltip='${test.gradeButtonTooltip}'
-						.reportsButtonTooltip='${test.reportsButtonTooltip}'
-						.letterGradeOptions=${test.letterGradeOptions}
-						.selectedLetterGrade='${test.selectedLetterGrade}'
-						?includeGradeButton=${test.includeGradeButton}
-						?includeReportsButton=${test.includeReportsButton}
-						?showFlooredScoreWarning=${test.showFlooredScoreWarning}
-						?allowNegativeScore=${test.allowNegativeScore}
+						grade-type="${test.gradeType}"
+						label-text="${test.labelText}"
+						score-numerator="${ifDefined(test.scoreNumerator)}"
+						score-denominator="${ifDefined(test.scoreDenominator)}"
+						grade-button-tooltip="${ifDefined(test.gradeButtonTooltip)}"
+						reports-button-tooltip="${ifDefined(test.reportsButtonTooltip)}"
+						.letterGradeOptions="${test.letterGradeOptions}"
+						selected-letter-grade="${ifDefined(test.selectedLetterGrade)}"
+						?include-grade-button="${test.includeGradeButton}"
+						?include-reports-button="${test.includeReportsButton}"
+						?show-floored-score-warning="${test.showFlooredScoreWarning}"
+						?allow-negative-score="${test.allowNegativeScore}"
 					></d2l-labs-grade-result-presentational>
 				<div>`,
 				{ pagePadding: false }


### PR DESCRIPTION
Many of the `<d2l-labs-grade-result-*>` components don't adhere to our kebab-case guidance for multi-word attributes, and we want to resolve that.

This change is going to happen in 3 stages:
1. Go through consumers of the components and add both kebab-case and non-kebab-case attributes (complete ✅)
2. Switch the `<d2l-labs-grade-result-*>` components to only support kebab-case (this PR)
3. Go back through consumers and remove the non-kebab-case attributes