### PR TITLE
NTNGL-4224 | Router Navigate Can Pass Data

### DIFF
--- a/src/utilities/router/index.js
+++ b/src/utilities/router/index.js
@@ -1,2 +1,2 @@
-export { ContextReactor, redirect, navigate, registerRoutes, RouterTesting } from './router.js';
+export { ContextReactor, redirect, navigate, navigateAndPass, registerRoutes, RouterTesting } from './router.js';
 export { RouteReactor } from './RouteReactor.js';

--- a/src/utilities/router/router.js
+++ b/src/utilities/router/router.js
@@ -3,6 +3,7 @@ import page from 'page';
 let activePage = page;
 let _lastOptions = {};
 let _lastContext = {};
+let passedData = undefined;
 
 export const _createReducedContext = pageContext => ({
 	params: pageContext.params,
@@ -13,6 +14,7 @@ export const _createReducedContext = pageContext => ({
 	route: pageContext.routePath,
 	title: pageContext.title,
 	options: {},
+	passedData
 });
 
 const _storeCtx = () => {
@@ -27,7 +29,9 @@ const _handleRouteView = (context, next, r) => {
 		const reducedContext = _createReducedContext(context);
 		context.view = (host, options) => {
 			reducedContext.options = options || {};
-			return r.view.call(host, reducedContext);
+			const resultingView = r.view.call(host, reducedContext);
+			passedData = undefined;
+			return resultingView;
 		};
 		context.handled = true;
 
@@ -119,6 +123,13 @@ const addMiddleware = callback => {
 // Triggers navigation to the specified route path.
 // Creates a new entry in the browser's history stack.
 export const navigate = path => {
+	activePage.show(path);
+};
+
+// Triggers navigation to the specified route path and passes along some data.
+// Creates a new entry in the browser's history stack.
+export const navigateAndPass = (path, data) => {
+	passedData = data;
 	activePage.show(path);
 };
 

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -1,7 +1,7 @@
 import './helpers/main-view.js';
 import './helpers/param-query-view.js';
 import { aTimeout, expect, fixture, html, waitUntil } from '@brightspace-ui/testing';
-import { navigate, registerRoutes, RouterTesting } from '../../../src/utilities/router/index.js';
+import { navigate, navigateAndPass, registerRoutes, RouterTesting } from '../../../src/utilities/router/index.js';
 import { loader as load1 } from './helpers/route-loader-1.js';
 import { loader as load2 } from './helpers/route-loader-2.js';
 
@@ -51,6 +51,10 @@ const initRouter = () => {
 				view() {
 					return html`<p>${this['main-prop']}</p>`;
 				},
+			},
+			{
+				pattern: '/pass',
+				view: ctx => html`<p>${ctx.passedData}</p>`
 			},
 			load1,
 			load2,
@@ -184,6 +188,25 @@ describe('Router', () => {
 		);
 		const p = entryPoint.shadowRoot.querySelector('p').innerText;
 		expect(p).to.equal('Passed');
+	});
+
+	it('Should receive passed values from navigateAndPass', async() => {
+		// chech that data can be passed
+		navigateAndPass('/pass', { hello: 'world' });
+		await entryPoint.updateComplete;
+		await waitUntil(
+			() => entryPoint.shadowRoot.querySelector('p') !== null
+		);
+		const p1 = entryPoint.shadowRoot.querySelector('p').innerText;
+		expect(p1).to.equal('world');
+
+		// validate that data isn't accessible after the first pass
+		navigate('/pass');
+		await waitUntil(
+			() => entryPoint.shadowRoot.querySelector('p') !== null
+		);
+		const p2 = entryPoint.shadowRoot.querySelector('p').innerText;
+		expect(p2).to.equal('undefined');
 	});
 
 	it('Should receive entry-point as this', async() => {

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -191,14 +191,14 @@ describe('Router', () => {
 	});
 
 	it('Should receive passed values from navigateAndPass', async() => {
-		// chech that data can be passed
-		navigateAndPass('/pass', { hello: 'world' });
+		// check that data can be passed
+		navigateAndPass('/pass', 'hello world');
 		await entryPoint.updateComplete;
 		await waitUntil(
 			() => entryPoint.shadowRoot.querySelector('p') !== null
 		);
 		const p1 = entryPoint.shadowRoot.querySelector('p').innerText;
-		expect(p1).to.equal('world');
+		expect(p1).to.equal('hello world');
 
 		// validate that data isn't accessible after the first pass
 		navigate('/pass');
@@ -206,7 +206,7 @@ describe('Router', () => {
 			() => entryPoint.shadowRoot.querySelector('p') !== null
 		);
 		const p2 = entryPoint.shadowRoot.querySelector('p').innerText;
-		expect(p2).to.equal('undefined');
+		expect(p2).to.equal('');
 	});
 
 	it('Should receive entry-point as this', async() => {


### PR DESCRIPTION
During a call we came up with a pretty common scenario.

If an api makes an edit to a page a best practice is to return the new object back to the client. If you then navigated to the view page for that object you could either
 - make use of the view object that you were just given
 - call the server for the view object again
 
This change gives applications a handy way of passing data from one view to another without storing it in a context or other global store. 

Functional 
 - [x] Views can access passed data 
 - [x] Passed data is deleted after given to a view 