### PR TITLE
GAUD-8369 - Add menu-item-links to router demo

### DIFF
--- a/demo/utilities/router/app.js
+++ b/demo/utilities/router/app.js
@@ -1,4 +1,6 @@
 import './route-loader.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item-link.js';
 import { css, html, LitElement } from 'lit';
 import { basePath } from './util.js';
 import { RouteReactor } from '../../../src/utilities/router/index.js';
@@ -8,10 +10,13 @@ export class App extends LitElement {
 		:host {
 			display: grid;
 			grid-template-areas: "nav main";
-			grid-template-columns: 200px 1fr;
+			grid-template-columns: 250px 1fr;
 		}
 		aside {
 			grid-area: nav;
+		}
+		nav {
+			padding: 1rem;
 		}
 		main {
 			grid-area: main;
@@ -27,11 +32,18 @@ export class App extends LitElement {
 		return html`
 			<aside>
 				<nav>
+					Native Links
 					<ul>
 						<li><a href="${basePath}/home">Home</a></li>
 						<li><a href="${basePath}/people">People</a></li>
 						<li><a href="${basePath}/places">Places</a></li>
 					</ul>
+					Menu Item Links
+					<d2l-menu label="Nav Menu">
+						<d2l-menu-item-link href="${basePath}/home" text="Home"></d2l-menu-item-link>
+						<d2l-menu-item-link href="${basePath}/people" text="People"></d2l-menu-item-link>
+						<d2l-menu-item-link href="${basePath}/places" text="Places"></d2l-menu-item-link>
+					</d2l-menu>
 				</nav>
 			</aside>
 			<main>${this.route.renderView()}</main>


### PR DESCRIPTION
`d2l-menu-item-link` now works with the router (https://github.com/BrightspaceUI/core/pull/6016). Used these changes for testing - adding menu-item-links to the router demo.