### PR TITLE
NTNGL-4224 | Loader can access Context

### DIFF
--- a/demo/utilities/router/route-loader.js
+++ b/demo/utilities/router/route-loader.js
@@ -8,8 +8,11 @@ registerRoutes(
 	[
 		{
 			pattern: '/',
-			loader: () => import('./home.js'),
-			view: () => html`<test-home></test-home>`,
+			loader: async(ctx) => {
+				await import('./home.js');
+				ctx.loaderData = 'test';
+			},
+			view: ({ loaderData }) => html`<test-home>${ loaderData }</test-home>`,
 		},
 		{
 			pattern: '/home',

--- a/src/utilities/router/router.js
+++ b/src/utilities/router/router.js
@@ -51,7 +51,7 @@ const _handleRouteLoader = r => (context, next) => {
 	}
 
 	if (r.loader) {
-		r.loader().then(() => {
+		r.loader(context).then(() => {
 			_handleRouteView(context, next, r);
 		});
 	} else if (r.pattern && r.to) {

--- a/src/utilities/router/router.js
+++ b/src/utilities/router/router.js
@@ -13,8 +13,9 @@ export const _createReducedContext = pageContext => ({
 	hash: pageContext.hash,
 	route: pageContext.routePath,
 	title: pageContext.title,
+	loaderData: pageContext.loaderData,
 	options: {},
-	passedData
+	passedData,
 });
 
 const _storeCtx = () => {

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -59,10 +59,10 @@ const initRouter = () => {
 			{
 				pattern: '/ctx-load',
 				loader: ctx => {
-					ctx.passedData = 'Loaded from loader';
+					ctx.loaderData = 'Loaded from loader';
 					return Promise.resolve();
 				},
-				view: ctx => html`<p>${ctx.passedData}</p>`
+				view: ctx => html`<p>${ctx.loaderData}</p>`
 			},
 			load1,
 			load2,

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -56,6 +56,14 @@ const initRouter = () => {
 				pattern: '/pass',
 				view: ctx => html`<p>${ctx.passedData}</p>`
 			},
+			{
+				pattern: '/ctx-load',
+				loader: ctx => {
+					ctx.passedData = 'Loaded from loader';
+					return Promise.resolve();
+				},
+				view: ctx => html`<p>${ctx.passedData}</p>`
+			},
 			load1,
 			load2,
 		],
@@ -207,6 +215,13 @@ describe('Router', () => {
 		);
 		const p2 = entryPoint.shadowRoot.querySelector('p').innerText;
 		expect(p2).to.equal('');
+	});
+
+	it('Should access context from loader and modify it', async() => {
+		navigate('/ctx-load');
+		await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+		const p = entryPoint.shadowRoot.querySelector('p').innerText;
+		expect(p).to.equal('Loaded from loader');
 	});
 
 	it('Should receive entry-point as this', async() => {


### PR DESCRIPTION
This allows us to use the loader as a means of loading other kinds of data other than just js modules. e.g.

``` javascript
registerRoutes([
	{
		pattern: '/d2l/ap/InsightsPortal/:orgUnitId/:tab',
		loader: async(ctx) => {
			const importPromise = import('./app.js');
			const dataPromise = (async() => {
				const result = await fetch('/need/more/data');
				ctx.loaderData= await result.json();
			})();
			await Promise.all([dataPromise, importPromise]);
		},
		view: ({ loaderData}) => html`<d2l-my-app .loaderData=${options.loaderData}></d2l-my-app>`
	}
], {});
```