### PR TITLE
Make video element not focusable in Firefox.

### DIFF
--- a/src/components/media-player/media-player.js
+++ b/src/components/media-player/media-player.js
@@ -1234,6 +1234,7 @@ class MediaPlayer extends LocalizeLabsElement(RtlMixin(LitElement)) {
 						@playing=${this._onPlaying}
 						@pause=${this._onPause}
 						@loadedmetadata=${this._onLoadedMetadata}
+						tabindex="-1"
 						@timeupdate=${this._onTimeUpdate}
 						@volumechange=${this._onVolumeChange}
 					>


### PR DESCRIPTION
[GAUD-8550](https://desire2learn.atlassian.net/browse/GAUD-8550)

This PR adds `tabindex="-1"` to `d2l-labs-media-player`'s `video` to ensure that focus does not land on a hidden tabstop when using Firefox. This also normalizes the behaviour - Safari and Chrome already behave this way.

There is a lengthly discussion [here on Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=486899) regarding keyboard a11y of the video element. I _think_ they add this tabstop to access default video controls, which we don't use.

Tested `audio` and it did not seem to have this issue, so no change made there.

[GAUD-8550]: https://desire2learn.atlassian.net/browse/GAUD-8550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ