### PR TITLE
Remove RtlMixin from d2l-labs-pager-numeric.

### DIFF
--- a/src/components/pagination/pager-numeric.js
+++ b/src/components/pagination/pager-numeric.js
@@ -4,10 +4,9 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css, html, LitElement } from 'lit';
 import { formatNumber } from '@brightspace-ui/intl';
 import { LocalizeLabsElement } from '../localize-labs-element.js';
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 
-class PagerNumeric extends RtlMixin(LocalizeLabsElement(LitElement)) {
+class PagerNumeric extends LocalizeLabsElement(LitElement) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
[GAUD-8920](https://desire2learn.atlassian.net/browse/GAUD-8920)

I think the `RtlMixin` was being included for `selectStyles` which no longer relies on it.

[GAUD-8920]: https://desire2learn.atlassian.net/browse/GAUD-8920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ