### PR TITLE
Cleanup RtlMixin in opt-in/out components.

### DIFF
--- a/src/components/opt-in-flyout/opt-out-dialog.js
+++ b/src/components/opt-in-flyout/opt-out-dialog.js
@@ -4,7 +4,6 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/inputs/input-textarea.js';
 import './opt-out-reason-selector.js';
 import { css, html, LitElement } from 'lit';
-import { composeMixins } from '@brightspace-ui/core/helpers/composeMixins.js';
 import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 const defaultEventProperties = {
@@ -12,10 +11,7 @@ const defaultEventProperties = {
 	composed: true
 };
 
-class OptOutDialog extends composeMixins(
-	LitElement,
-	LocalizeLabsElement
-) {
+class OptOutDialog extends LocalizeLabsElement(LitElement) {
 
 	static get properties() {
 		return {

--- a/src/components/opt-in-flyout/opt-out-reason-selector.js
+++ b/src/components/opt-in-flyout/opt-out-reason-selector.js
@@ -1,13 +1,10 @@
 import './opt-out-reason.js';
 import { css, html, LitElement } from 'lit';
-import { composeMixins } from '@brightspace-ui/core/helpers/composeMixins.js';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { LocalizeLabsElement } from '../localize-labs-element.js';
 
-class OptOutReasonSelector extends composeMixins(
-	LitElement,
-	LocalizeLabsElement
-) {
+class OptOutReasonSelector extends LocalizeLabsElement(LitElement) {
+
 	static get properties() {
 		return {
 			_reasons: { state: true }


### PR DESCRIPTION
[GAUD-8922](https://desire2learn.atlassian.net/browse/GAUD-8922)

Remove `RtlMixin` from `d2l-labs-opt-out-reason-selector` and `d2l-labs-opt-out-dialog`.

[GAUD-8922]: https://desire2learn.atlassian.net/browse/GAUD-8922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ