### PR TITLE
GAUD-8354 - Use new dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      # update-package-lock workflow already handles minor/patch updates
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    cooldown:
+      # update-package-lock workflow handles minor/patch updates - delay for a few weeks to give time to handle breaking changes in those PRs
+      default-days: 25
+      semver-major-days: 5


### PR DESCRIPTION
We set this up in https://github.com/BrightspaceUI/core/pull/5938 and it seems to be working well.

Dependabot released a [new feature](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/) that allows you to set a "cooldown" period for a package version before a PR is opened to update to it.

Currently, we ignore minor and patch updates from Dependabot because those are handled by `update-package-lock` and having both is super noisy. But this means we miss new `0.x` and `0.0.x` versions bumps completely. This new option solves that issue - we still get major bumps quickly and these `0` versions eventually.