### PR TITLE
Expose Router Middleware

### DIFF
--- a/src/utilities/router/index.js
+++ b/src/utilities/router/index.js
@@ -1,2 +1,2 @@
-export { ContextReactor, redirect, navigate, registerRoutes, RouterTesting } from './router.js';
+export { ContextReactor, redirect, navigate, registerRoutes, addMiddleware, RouterTesting } from './router.js';
 export { RouteReactor } from './RouteReactor.js';

--- a/src/utilities/router/router.js
+++ b/src/utilities/router/router.js
@@ -114,8 +114,12 @@ export const registerRoutes = (routes, options) => {
 	_storeCtx();
 };
 
-const addMiddleware = callback => {
-	activePage('*', (ctx, next) => {
+/**
+ *  Used internally to decide which view should be loaded and then rendered.
+ *  Additional middleware added will be run after your view has been selected.
+ */
+export const addMiddleware = (callback, pattern = '*') => {
+	activePage(pattern, (ctx, next) => {
 		callback(ctx);
 		next();
 	});

--- a/test/utilities/router/router.test.js
+++ b/test/utilities/router/router.test.js
@@ -1,9 +1,12 @@
 import './helpers/main-view.js';
 import './helpers/param-query-view.js';
+import { addMiddleware, navigate, registerRoutes, RouterTesting } from '../../../src/utilities/router/index.js';
 import { aTimeout, expect, fixture, html, waitUntil } from '@brightspace-ui/testing';
-import { navigate, registerRoutes, RouterTesting } from '../../../src/utilities/router/index.js';
 import { loader as load1 } from './helpers/route-loader-1.js';
 import { loader as load2 } from './helpers/route-loader-2.js';
+import Sinon from 'sinon';
+
+const sinon = Sinon.createSandbox();
 
 let entryPoint;
 
@@ -232,5 +235,21 @@ describe('Router', () => {
 		);
 		const p = entryPoint.shadowRoot.querySelector('p').innerText;
 		expect(p).to.equal('Passed');
+	});
+
+	it('Should call any added middleware', async() => {
+
+		const testMiddleware = sinon.fake();
+
+		await entryPoint.updateComplete;
+		await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+
+		addMiddleware(testMiddleware);
+		navigate('/ctx-load');
+
+		await entryPoint.updateComplete;
+		await waitUntil(() => entryPoint.shadowRoot.querySelector('p'));
+		expect(testMiddleware.calledOnce).to.be.true;
+		expect(testMiddleware.firstCall.args[0]).to.have.property('path', '/ctx-load');
 	});
 });


### PR DESCRIPTION
### Implementation Details

On Nightingale we've run into a few cases where being able to run some code after the view has been selected is pretty useful. Cases like:
 - Announcing that the view has changed to the screen reader
 - Creating new traces for performance metrics
 
 This was technically possible before by doing the following:
 
 ``` javascript
 constructor() {
  super();
  ...
  new ContextReactor(undefined, () => {
    // code that gets run after the view changes
  }) 
 }
 ```
 
But, in hindsight, it's odd that you have to add it to the controller that updates the entrypoint view. So instead, with the exposed middleware function, that would look something like this instead

```javascript
// my router extension
import { addMiddleware } from 'router';

addMiddleware(() => {
  // code that gets run after the view changes
})
```

One convenient place for these extensions might be the apps route-loader. This labs folder could also have a standard set of middleware that teams can add as needed.

### Quality Notes

Functional Testing
  - [x] Middleware are run when added to the chain