### PR TITLE
GAUD-9791: fix aria-controls

### DIFF
--- a/src/components/accordion/accordion-collapse.js
+++ b/src/components/accordion/accordion-collapse.js
@@ -221,7 +221,7 @@ class LabsAccordionCollapse extends LitElement {
 	render() {
 		return html`
 			<div id="header-container">
-				<a href="javascript:void(0)" id="trigger" ?aria-expanded=${this.opened} class="header-grid-item" aria-controls="collapse" role="button" ?data-border="${this.headerBorder}" @blur=${this._triggerBlur} @click=${this.toggle} @focus=${this._triggerFocus}>
+				<a href="javascript:void(0)" id="trigger" aria-expanded=${this.opened ? 'true' : 'false'} class="header-grid-item" aria-controls="collapse" role="button" ?data-border="${this.headerBorder}" @blur=${this._triggerBlur} @click=${this.toggle} @focus=${this._triggerFocus}>
 					${!this.headerHasInteractiveContent ? html`
 						<div class="collapse-title" title="${this.label}">${this.title}${this.label}<slot name="header"></slot>
 						</div>
@@ -243,7 +243,7 @@ class LabsAccordionCollapse extends LitElement {
 				` : nothing}
 			</div>
 
-			<div class="content">
+			<div class="content" id="collapse">
 				<d2l-expand-collapse-content ?expanded=${this.opened} @d2l-expand-collapse-content-expand=${this._handleExpand} @d2l-expand-collapse-content-collapse=${this._handleCollapse}>
 					<slot></slot>
 				</d2l-expand-collapse-content>

--- a/test/components/accordion/accordion.test.js
+++ b/test/components/accordion/accordion.test.js
@@ -18,6 +18,11 @@ const accordionCollapseFixtureLabel = html`
 
 describe('d2l-labs-accordion', () => {
 
+	it('accessibility', async() => {
+		const myEl = await fixture(accordionCollapseFixtureLabel);
+		await expect(myEl).to.be.accessible();
+	});
+
 	it('initial select state', async() => {
 		const myEl = await fixture(accordionCollapseFixture);
 		expect(myEl.selected).to.not.exist;


### PR DESCRIPTION
The `aria-controls` here is pointing at nothing, which was being caught in Lighthouse and axe. Looks like it was broken [about 6 years ago!](https://github.com/BrightspaceUI/labs/commit/6af46fdf754837cef6be860084ef51fb8ad73e2d)! 😬 

Also fixing `aria-expanded`, which is a string not a boolean.