### PR TITLE
MED-2833: Suppress benign AbortError

### DIFF
--- a/src/components/media-player/media-player.js
+++ b/src/components/media-player/media-player.js
@@ -1576,7 +1576,7 @@ class MediaPlayer extends LocalizeLabsElement(RtlMixin(LitElement)) {
 			this._updateCurrentTimeFromSeekbarProgress();
 
 			if (this._pausedForSeekDrag) {
-				this._media.play();
+				this._play();
 			}
 			this._dragging = false;
 		}
@@ -2030,6 +2030,12 @@ class MediaPlayer extends LocalizeLabsElement(RtlMixin(LitElement)) {
 		return quality;
 	}
 
+	// Calling play() returns a Promise. If pause() is called before that Promise resolves,
+	// the browser rejects it with an AbortError. This is benign, so we suppress it.
+	_play() {
+		return this._media.play().catch((e) => { if (e.name !== 'AbortError') throw e; });
+	}
+
 	_reloadSource() {
 		if (this._media) {
 			const oldSourceNode = this._media.getElementsByTagName('source')[0];
@@ -2243,7 +2249,7 @@ class MediaPlayer extends LocalizeLabsElement(RtlMixin(LitElement)) {
 				this._loadVisibilityObserver({ target: this._mediaContainer });
 			}
 			this._playRequested = true;
-			this._media.play();
+			this._play();
 		} else {
 			this._playRequested = false;
 			this._media.pause();

--- a/test/components/media-player/media-player.test.js
+++ b/test/components/media-player/media-player.test.js
@@ -29,13 +29,7 @@ describe('d2l-labs-media-player', () => {
 				configurable: true,
 				get: () => ({ play: () => Promise.reject(abortError) })
 			});
-			let threw = false;
-			try {
-				await el._play();
-			} catch {
-				threw = true;
-			}
-			expect(threw).to.be.false;
+			await el._play();
 		});
 
 		it('should rethrow non-AbortError errors from play()', async() => {

--- a/test/components/media-player/media-player.test.js
+++ b/test/components/media-player/media-player.test.js
@@ -29,6 +29,8 @@ describe('d2l-labs-media-player', () => {
 				configurable: true,
 				get: () => ({ play: () => Promise.reject(abortError) })
 			});
+			// An unhandled rejection in an async test function causes the test to fail,
+			// so if the AbortError is not suppressed, this call will fail the test
 			await el._play();
 		});
 

--- a/test/components/media-player/media-player.test.js
+++ b/test/components/media-player/media-player.test.js
@@ -15,4 +15,42 @@ describe('d2l-labs-media-player', () => {
 			runConstructor('d2l-labs-media-player');
 		});
 	});
+
+	describe('_play()', () => {
+		let el;
+
+		beforeEach(async() => {
+			el = await fixture(html`<d2l-labs-media-player></d2l-labs-media-player>`);
+		});
+
+		it('should suppress AbortError when play() is interrupted by pause()', async() => {
+			const abortError = new DOMException('The play() request was interrupted by a call to pause().', 'AbortError');
+			Object.defineProperty(el, '_media', {
+				configurable: true,
+				get: () => ({ play: () => Promise.reject(abortError) })
+			});
+			let threw = false;
+			try {
+				await el._play();
+			} catch {
+				threw = true;
+			}
+			expect(threw).to.be.false;
+		});
+
+		it('should rethrow non-AbortError errors from play()', async() => {
+			const mediaError = new Error('MediaError');
+			Object.defineProperty(el, '_media', {
+				configurable: true,
+				get: () => ({ play: () => Promise.reject(mediaError) })
+			});
+			let caught = null;
+			try {
+				await el._play();
+			} catch (e) {
+				caught = e;
+			}
+			expect(caught).to.equal(mediaError);
+		});
+	});
 });


### PR DESCRIPTION
Suppress an intermittent AbortError in the media-player to reduce console noise. The error is difficult to reproduce. I was able to reproduce it a few times with the following steps:

1. Pressing Play
2. Pressing Pause
3. Waiting for the media URL to expire
4. Pressing Play

In this scenario, playback recovered successfully by loading a new source with no user impact. 

Subsequent attempts to reproduce the error - including simulating an immediate pause after play - were unsuccessful, and it's unclear if other scenarios exist that can trigger it.

With no known user impact and no related support tickets, this appears to be a benign, self-recovering error and is safe to suppress.