### PR TITLE
GAUD-10267: use modern static properties

### DIFF
--- a/demo/components/ou-filter/ouFilterDemoPage.js
+++ b/demo/components/ou-filter/ouFilterDemoPage.js
@@ -16,22 +16,20 @@ function parseHash(hash) {
 /* eslint-disable no-console */
 class OuFilterDemoPage extends MobxLitElement {
 
-	static get styles() {
-		return [
-			css`
-				:host {
-					display: inline-block;
-				}
-				div {
-					padding: 30px;
-				}
-				label {
-					display: block;
-					margin-top: 25px;
-				}
-			`
-		];
-	}
+	static styles = [
+		css`
+			:host {
+				display: inline-block;
+			}
+			div {
+				padding: 30px;
+			}
+			label {
+				display: block;
+				margin-top: 25px;
+			}
+		`
+	];
 
 	constructor() {
 		super();

--- a/demo/utilities/reactive-store/index.html
+++ b/demo/utilities/reactive-store/index.html
@@ -27,11 +27,9 @@
 				<d2l-code-view language="js">import ReactiveStore from '../../../src/utilities/reactive-store/reactive-store.js';
 
 export default class MyStore extends ReactiveStore {
-	static get properties() {
-		return {
-			count: { type: Number },
-		};
-	}
+	static properties = {
+		count: { type: Number },
+	};
 
 	constructor() {
 		super();
@@ -52,13 +50,11 @@ export default class MyStore extends ReactiveStore {
 				<d2l-code-view language="js">import ReactiveStore from '../../../src/utilities/reactive-store/reactive-store.js';
 
 export default class MultiPropStore extends ReactiveStore {
-	static get properties() {
-		return {
-			foo: { type: Number },
-			bar: { type: Number },
-			baz: { type: Number },
-		};
-	}
+	static properties = {
+		foo: { type: Number },
+		bar: { type: Number },
+		baz: { type: Number },
+	};
 
 	constructor() {
 		super();

--- a/demo/utilities/reactive-store/multi-prop-store.js
+++ b/demo/utilities/reactive-store/multi-prop-store.js
@@ -1,13 +1,11 @@
 import ReactiveStore from '../../../src/utilities/reactive-store/reactive-store.js';
 
 export default class MultiPropStore extends ReactiveStore {
-	static get properties() {
-		return {
-			foo: { type: Number },
-			bar: { type: Number },
-			baz: { type: Number },
-		};
-	}
+	static properties = {
+		foo: { type: Number },
+		bar: { type: Number },
+		baz: { type: Number },
+	};
 
 	constructor() {
 		super();

--- a/demo/utilities/reactive-store/my-store.js
+++ b/demo/utilities/reactive-store/my-store.js
@@ -1,11 +1,9 @@
 import ReactiveStore from '../../../src/utilities/reactive-store/reactive-store.js';
 
 export default class MyStore extends ReactiveStore {
-	static get properties() {
-		return {
-			count: { type: Number },
-		};
-	}
+	static properties = {
+		count: { type: Number },
+	};
 
 	constructor() {
 		super();

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 import { html, LitElement } from 'lit';
 
 export class BuildInfo extends LitElement {
-	static get properties() {
-		return {
-			_buildDate: { state: true },
-			_buildVersion: { state: true },
-		};
-	}
+	static properties = {
+		_buildDate: { state: true },
+		_buildVersion: { state: true },
+	};
 
 	constructor() {
 		super();

--- a/src/components/accessibility-disability-simulator/accessibility-disability-simulator.js
+++ b/src/components/accessibility-disability-simulator/accessibility-disability-simulator.js
@@ -23,81 +23,77 @@ const otherTypes = Object.entries(DISABILITY_TYPES).filter(value => !value[0].in
 
 class AccessibilityDisabilitySimulator extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * The level of blurriness when the low-vision filter is being used, should range between 1 and 100
-			 * @type {Number}
-			 */
-			blurLevel: { type: Number, attribute: 'blur-level', reflect: true },
-			/**
-			 * The type of disability to simulate
-			 * @type {'no-vision'|'low-vision'|'keyboard-only'|'colorblind-achromatopsia'|'colorblind-deuteranopia'|'colorblind-protanopia'|'colorblind-tritanopia'}
-			 */
-			disabilityType: { type: String, attribute: 'disability-type', reflect: true },
-			/**
-			 * Whether or not the alert should be shown
-			 * @type {Boolean}
-			 */
-			hideAlert: { type: Boolean, attribute: 'hide-alert' },
-			/**
-			 * Whether or not to show the disability type selection and blur level controls
-			 * @type {Boolean}
-			 */
-			hideControls: { type: Boolean, attribute: 'hide-controls' }
-		};
-	}
+	static properties = {
+		/**
+		 * The level of blurriness when the low-vision filter is being used, should range between 1 and 100
+		 * @type {Number}
+		 */
+		blurLevel: { type: Number, attribute: 'blur-level', reflect: true },
+		/**
+		 * The type of disability to simulate
+		 * @type {'no-vision'|'low-vision'|'keyboard-only'|'colorblind-achromatopsia'|'colorblind-deuteranopia'|'colorblind-protanopia'|'colorblind-tritanopia'}
+		 */
+		disabilityType: { type: String, attribute: 'disability-type', reflect: true },
+		/**
+		 * Whether or not the alert should be shown
+		 * @type {Boolean}
+		 */
+		hideAlert: { type: Boolean, attribute: 'hide-alert' },
+		/**
+		 * Whether or not to show the disability type selection and blur level controls
+		 * @type {Boolean}
+		 */
+		hideControls: { type: Boolean, attribute: 'hide-controls' }
+	};
 
-	static get styles() {
-		return [ bodyCompactStyles, bodyStandardStyles, offscreenStyles, selectStyles, css`
-			.simulator-controls {
-				align-items: center;
-				display: flex;
-				gap: 0.5rem;
-				margin-bottom: 1rem;
-			}
+	static styles = [bodyCompactStyles, bodyStandardStyles, offscreenStyles, selectStyles, css`
+		.simulator-controls {
+			align-items: center;
+			display: flex;
+			gap: 0.5rem;
+			margin-bottom: 1rem;
+		}
 
-			.low-vision-slider {
-				align-items: center;
-				display: flex;
-				gap: 0.5rem;
-			}
+		.low-vision-slider {
+			align-items: center;
+			display: flex;
+			gap: 0.5rem;
+		}
 
-			.alert-message {
-				display: inline-block;
-				margin-bottom: 1rem;
-				padding: 0.5rem;
-			}
+		.alert-message {
+			display: inline-block;
+			margin-bottom: 1rem;
+			padding: 0.5rem;
+		}
 
-			.svg-filter {
-				display: none;
-			}
+		.svg-filter {
+			display: none;
+		}
 
-			:host([disability-type="keyboard-only"]) .wrapper-slot {
-				pointer-events: none;
-			}
+		:host([disability-type="keyboard-only"]) .wrapper-slot {
+			pointer-events: none;
+		}
 
-			:host([disability-type="no-vision"]) .wrapper-slot {
-				filter: grayscale(1);
-			}
+		:host([disability-type="no-vision"]) .wrapper-slot {
+			filter: grayscale(1);
+		}
 
-			:host([disability-type="colorblind-achromatopsia"]) .wrapper-slot {
-				filter: grayscale(1);
-			}
+		:host([disability-type="colorblind-achromatopsia"]) .wrapper-slot {
+			filter: grayscale(1);
+		}
 
-			:host([disability-type="colorblind-deuteranopia"]) .wrapper-slot {
-				filter: url("#deuteranopia");
-			}
+		:host([disability-type="colorblind-deuteranopia"]) .wrapper-slot {
+			filter: url("#deuteranopia");
+		}
 
-			:host([disability-type="colorblind-protanopia"]) .wrapper-slot {
-				filter: url("#protanopia");
-			}
+		:host([disability-type="colorblind-protanopia"]) .wrapper-slot {
+			filter: url("#protanopia");
+		}
 
-			:host([disability-type="colorblind-tritanopia"]) .wrapper-slot {
-				filter: url("#tritanopia");
-			}
-		` ];
-	}
+		:host([disability-type="colorblind-tritanopia"]) .wrapper-slot {
+			filter: url("#tritanopia");
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/accordion/accordion-collapse.js
+++ b/src/components/accordion/accordion-collapse.js
@@ -6,172 +6,169 @@ import { findComposedAncestor, isComposedAncestor } from '@brightspace-ui/core/h
 import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offscreen.js';
 
 class LabsAccordionCollapse extends LitElement {
-	static get properties() {
-		return {
-			/**
-			 * Label. Does not apply title to entire accordion
-			 */
-			label: { type: String },
-			/**
-			 * Header text hidden on the screen, but to be read by a screen reader
-			 */
-			screenReaderHeaderText: { type: String, attribute: 'screen-reader-header-text' },
-			/**
-			 * Corresponds to the iron-collapse's noAnimation property.
-			 */
-			noAnimation: { type: Boolean, attribute: 'no-animation' },
-			/**
-			 * Whether currently expanded.
-			 */
-			opened: { type: Boolean, reflect: true },
-			/**
-			 * The icon when collapsed.
-			 */
-			expandIcon: { type: String, attribute: 'expand-icon' },
-			/**
-			 * The icon when expanded.
-			 */
-			collapseIcon: { type: String, attribute: 'collapse-icon' },
-			/**
-			 * Whether to hide the expand/collapse icon.
-			 */
-			noIcons: { type: Boolean, attribute: 'no-icons' },
-			/**
-			 * Whether or not to use flex layout.
-			 */
-			flex: { type: Boolean, reflect: true },
-			/**
-			 * Whether or not to add extra padding for icon.
-			 */
-			iconHasPadding: { type: Boolean, attribute: 'icon-has-padding', reflect: true },
-			/**
-			 * Whether or not to add a border between the header and the content.
-			 */
-			headerBorder: { type: Boolean, attribute: 'header-border' },
-			/**
-			 * Whether the accordion's expand/collapse function is disabled.
-			 */
-			disabled: { type: Boolean, reflect: true },
-			/**
-			 * Whether or not to disable default focus styles
-			 */
-			disableDefaultTriggerFocus: { type: Boolean, attribute: 'disable-default-trigger-focus', reflect: true },
-			/**
-			 * Whether or not the header contains an interactive element inside it (e.g. clickable)
-			 */
-			headerHasInteractiveContent: { type: Boolean, attribute: 'header-has-interactive-content', reflect: true },
-			/**
-			 * Listener for state changes.
-			 */
-			_boundListener: { type: Function, attribute: '_bound-listener' },
-			/**
-			 * The current state of the accordion (opened, closed)
-			 */
-			_state: { type: String, reflect: true }
-		};
-	}
 
-	static get styles() {
-		return [offscreenStyles, css`
-	:host {
-		display: block;
-	}
-	#interactive-header-content {
-		align-items: center;
-		display: flex;
-	}
-	#trigger {
-		align-items: center;
-		display: flex;
-		text-decoration: none;
-	}
-	#trigger:focus-visible {
-		outline-offset: 3px;
-	}
-	#trigger[data-border] {
-		border-bottom: solid 1px var(--d2l-color-corundum);
-		margin-bottom: 0.4rem;
-		padding-bottom: 0.4rem;
-	}
-	#trigger, #trigger:visited, #trigger:hover, #trigger:active {
-		color: inherit;
-	}
-	:host([flex]) .collapse-title {
-		flex: 1;
-		flex-basis: 0.000000001px;
-		overflow: hidden;
-	}
-	:host([icon-has-padding]) d2l-icon {
-		padding-left: 1.25rem;
-		padding-right: 0;
-	}
-	:host([icon-has-padding][dir="rtl"]) d2l-icon {
-		padding-left: 0;
-		padding-right: 1.25rem;
-	}
-	:host([flex][icon-has-padding]) d2l-icon {
-		padding-left: 0;
-		padding-right: 1.25rem;
-	}
-	:host([flex][icon-has-padding][dir="rtl"]) d2l-icon {
-		padding-left: 1.25rem;
-		padding-right: 0;
-	}
-	.content {
-		height: auto;
-		margin: -1px;
-		padding: 1px;
-		position: relative;
-	}
-	.summary {
-		transition: opacity 500ms ease;
-	}
-	:host([_state="closing"]) .content,
-	:host([_state="opening"]) .content {
-		overflow: hidden;
-	}
-	:host([_state="closed"]) .summary,
-	:host([_state="closing"]) .summary {
-		transition-delay: 500ms;
-	}
-	:host([_state="opening"]) .summary,
-	:host([_state="opened"]) .summary {
-		opacity: 0;
-	}
-	:host([_state="closing"]) .summary,
-	:host([_state="opening"]) .summary,
-	:host([_state="opened"]) .summary {
-		pointer-events: none;
-		position: absolute;
-	}
-	:host([_state="closing"]) .summary,
-	:host([_state="opened"]) .summary {
-		transition-property: none;
-	}
-	:host([disabled]) a {
-		cursor: default;
-	}
-	:host([disabled]) d2l-icon {
-		color: var(--d2l-color-chromite);
-	}
-	:host([disable-default-trigger-focus]) #trigger:focus {
-		outline: none;
-	}
+	static properties = {
+		/**
+		 * Label. Does not apply title to entire accordion
+		 */
+		label: { type: String },
+		/**
+		 * Header text hidden on the screen, but to be read by a screen reader
+		 */
+		screenReaderHeaderText: { type: String, attribute: 'screen-reader-header-text' },
+		/**
+		 * Corresponds to the iron-collapse's noAnimation property.
+		 */
+		noAnimation: { type: Boolean, attribute: 'no-animation' },
+		/**
+		 * Whether currently expanded.
+		 */
+		opened: { type: Boolean, reflect: true },
+		/**
+		 * The icon when collapsed.
+		 */
+		expandIcon: { type: String, attribute: 'expand-icon' },
+		/**
+		 * The icon when expanded.
+		 */
+		collapseIcon: { type: String, attribute: 'collapse-icon' },
+		/**
+		 * Whether to hide the expand/collapse icon.
+		 */
+		noIcons: { type: Boolean, attribute: 'no-icons' },
+		/**
+		 * Whether or not to use flex layout.
+		 */
+		flex: { type: Boolean, reflect: true },
+		/**
+		 * Whether or not to add extra padding for icon.
+		 */
+		iconHasPadding: { type: Boolean, attribute: 'icon-has-padding', reflect: true },
+		/**
+		 * Whether or not to add a border between the header and the content.
+		 */
+		headerBorder: { type: Boolean, attribute: 'header-border' },
+		/**
+		 * Whether the accordion's expand/collapse function is disabled.
+		 */
+		disabled: { type: Boolean, reflect: true },
+		/**
+		 * Whether or not to disable default focus styles
+		 */
+		disableDefaultTriggerFocus: { type: Boolean, attribute: 'disable-default-trigger-focus', reflect: true },
+		/**
+		 * Whether or not the header contains an interactive element inside it (e.g. clickable)
+		 */
+		headerHasInteractiveContent: { type: Boolean, attribute: 'header-has-interactive-content', reflect: true },
+		/**
+		 * Listener for state changes.
+		 */
+		_boundListener: { type: Function, attribute: '_bound-listener' },
+		/**
+		 * The current state of the accordion (opened, closed)
+		 */
+		_state: { type: String, reflect: true }
+	};
 
-	:host([header-has-interactive-content]) #header-container {
-		display: grid;
-		grid-template-columns: auto;
-		grid-template-rows: auto;
-	}
-	:host([header-has-interactive-content]) .header-grid-item {
-		grid-column: 1;
-		grid-row: 1;
-	}
-	:host([header-has-interactive-content]) #interactive-header-content {
-		cursor: pointer;
-	}
-		`];
-	}
+	static styles = [offscreenStyles, css`
+		:host {
+			display: block;
+		}
+		#interactive-header-content {
+			align-items: center;
+			display: flex;
+		}
+		#trigger {
+			align-items: center;
+			display: flex;
+			text-decoration: none;
+		}
+		#trigger:focus-visible {
+			outline-offset: 3px;
+		}
+		#trigger[data-border] {
+			border-bottom: solid 1px var(--d2l-color-corundum);
+			margin-bottom: 0.4rem;
+			padding-bottom: 0.4rem;
+		}
+		#trigger, #trigger:visited, #trigger:hover, #trigger:active {
+			color: inherit;
+		}
+		:host([flex]) .collapse-title {
+			flex: 1;
+			flex-basis: 0.000000001px;
+			overflow: hidden;
+		}
+		:host([icon-has-padding]) d2l-icon {
+			padding-left: 1.25rem;
+			padding-right: 0;
+		}
+		:host([icon-has-padding][dir="rtl"]) d2l-icon {
+			padding-left: 0;
+			padding-right: 1.25rem;
+		}
+		:host([flex][icon-has-padding]) d2l-icon {
+			padding-left: 0;
+			padding-right: 1.25rem;
+		}
+		:host([flex][icon-has-padding][dir="rtl"]) d2l-icon {
+			padding-left: 1.25rem;
+			padding-right: 0;
+		}
+		.content {
+			height: auto;
+			margin: -1px;
+			padding: 1px;
+			position: relative;
+		}
+		.summary {
+			transition: opacity 500ms ease;
+		}
+		:host([_state="closing"]) .content,
+		:host([_state="opening"]) .content {
+			overflow: hidden;
+		}
+		:host([_state="closed"]) .summary,
+		:host([_state="closing"]) .summary {
+			transition-delay: 500ms;
+		}
+		:host([_state="opening"]) .summary,
+		:host([_state="opened"]) .summary {
+			opacity: 0;
+		}
+		:host([_state="closing"]) .summary,
+		:host([_state="opening"]) .summary,
+		:host([_state="opened"]) .summary {
+			pointer-events: none;
+			position: absolute;
+		}
+		:host([_state="closing"]) .summary,
+		:host([_state="opened"]) .summary {
+			transition-property: none;
+		}
+		:host([disabled]) a {
+			cursor: default;
+		}
+		:host([disabled]) d2l-icon {
+			color: var(--d2l-color-chromite);
+		}
+		:host([disable-default-trigger-focus]) #trigger:focus {
+			outline: none;
+		}
+
+		:host([header-has-interactive-content]) #header-container {
+			display: grid;
+			grid-template-columns: auto;
+			grid-template-rows: auto;
+		}
+		:host([header-has-interactive-content]) .header-grid-item {
+			grid-column: 1;
+			grid-row: 1;
+		}
+		:host([header-has-interactive-content]) #interactive-header-content {
+			cursor: pointer;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -2,24 +2,21 @@ import './accordion-collapse.js';
 import { css, html, LitElement } from 'lit';
 
 class LabsAccordion extends LitElement {
-	static get properties() {
-		return {
-			/**
-			 * Whether to automatically close other opened branches
-			 */
-			autoClose: { type: Boolean, attribute: 'auto-close' },
-			_selected: { type: Number }
-		};
-	}
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: block;
-			}
-		`;
-	}
+	static properties = {
+		/**
+		 * Whether to automatically close other opened branches
+		 */
+		autoClose: { type: Boolean, attribute: 'auto-close' },
+		_selected: { type: Number }
+	};
+
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: block;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/attribute-picker/attribute-picker-item.js
+++ b/src/components/attribute-picker/attribute-picker-item.js
@@ -6,73 +6,70 @@ import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/st
 import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 class AttributePickerItem extends LocalizeLabsElement(LitElement) {
-	static get properties() {
-		return {
-			deletable: { type: Boolean, reflect: true },
-			text: { type: String }
-		};
-	}
 
-	static get styles() {
-		return [bodyCompactStyles, css`
-			:host {
-				cursor: pointer;
-				display: inline-block;
-				width: max-content;
-			}
-			:host(:focus-visible) {
-				outline: none;
-			}
-			.d2l-labs-attribute-picker-item-wrapper {
-				align-items: center;
-				background-color: var(--d2l-color-sylvite);
-				border: 1px solid var(--d2l-color-gypsum);
-				border-radius: 0.3rem;
-				display: flex;
-				gap: 0.2rem;
-				padding: 0.25rem;
-				padding-inline: 0.5rem;
-				user-select: none;
-			}
-			:host([deletable]) .d2l-labs-attribute-picker-item-wrapper {
-				padding-inline: 0.5rem 0.1rem;
-				padding-bottom: 0.15rem;
-				padding-top: 0.1rem;
-			}
-			:host(:hover) .d2l-labs-attribute-picker-item-wrapper {
-				background-color: var(--d2l-color-gypsum);
-				border-color: var(--d2l-color-mica);
-				color: var(--d2l-color-ferrite);
-			}
-			:host(:focus) .d2l-labs-attribute-picker-item-wrapper {
-				background-color: var(--d2l-color-celestine);
-				border: 1px solid var(--d2l-color-celestine-minus-1);
-				color: var(--d2l-color-regolith);
-			}
-			.d2l-labs-attribute-picker-item-text {
-				-webkit-box-orient: vertical;
-				display: -webkit-box;
-				-webkit-line-clamp: 1;
-				line-height: normal;
-				max-width: 18rem;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				word-break: break-all;
-			}
-			d2l-button-icon {
-				--d2l-button-icon-background-color-hover: var(--d2l-color-mica);
-				--d2l-button-icon-fill-color: var(--d2l-color-chromite);
-				--d2l-button-icon-fill-color-hover: var(--d2l-color-tungsten);
-				--d2l-button-icon-min-height: 1.2rem;
-				--d2l-button-icon-min-width: 1.2rem;
-			}
-			:host(:focus) d2l-button-icon {
-				--d2l-button-icon-background-color-hover: var(--d2l-color-celestine-plus-1);
-				--d2l-button-icon-fill-color: var(--d2l-color-mica);
-				--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
-			}
-		`];
-	}
+	static properties = {
+		deletable: { type: Boolean, reflect: true },
+		text: { type: String }
+	};
+
+	static styles = [bodyCompactStyles, css`
+		:host {
+			cursor: pointer;
+			display: inline-block;
+			width: max-content;
+		}
+		:host(:focus-visible) {
+			outline: none;
+		}
+		.d2l-labs-attribute-picker-item-wrapper {
+			align-items: center;
+			background-color: var(--d2l-color-sylvite);
+			border: 1px solid var(--d2l-color-gypsum);
+			border-radius: 0.3rem;
+			display: flex;
+			gap: 0.2rem;
+			padding: 0.25rem;
+			padding-inline: 0.5rem;
+			user-select: none;
+		}
+		:host([deletable]) .d2l-labs-attribute-picker-item-wrapper {
+			padding-inline: 0.5rem 0.1rem;
+			padding-bottom: 0.15rem;
+			padding-top: 0.1rem;
+		}
+		:host(:hover) .d2l-labs-attribute-picker-item-wrapper {
+			background-color: var(--d2l-color-gypsum);
+			border-color: var(--d2l-color-mica);
+			color: var(--d2l-color-ferrite);
+		}
+		:host(:focus) .d2l-labs-attribute-picker-item-wrapper {
+			background-color: var(--d2l-color-celestine);
+			border: 1px solid var(--d2l-color-celestine-minus-1);
+			color: var(--d2l-color-regolith);
+		}
+		.d2l-labs-attribute-picker-item-text {
+			-webkit-box-orient: vertical;
+			display: -webkit-box;
+			-webkit-line-clamp: 1;
+			line-height: normal;
+			max-width: 18rem;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			word-break: break-all;
+		}
+		d2l-button-icon {
+			--d2l-button-icon-background-color-hover: var(--d2l-color-mica);
+			--d2l-button-icon-fill-color: var(--d2l-color-chromite);
+			--d2l-button-icon-fill-color-hover: var(--d2l-color-tungsten);
+			--d2l-button-icon-min-height: 1.2rem;
+			--d2l-button-icon-min-width: 1.2rem;
+		}
+		:host(:focus) d2l-button-icon {
+			--d2l-button-icon-background-color-hover: var(--d2l-color-celestine-plus-1);
+			--d2l-button-icon-fill-color: var(--d2l-color-mica);
+			--d2l-button-icon-fill-color-hover: var(--d2l-color-sylvite);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/attribute-picker/attribute-picker.js
+++ b/src/components/attribute-picker/attribute-picker.js
@@ -19,141 +19,138 @@ const keyCodes = {
 };
 
 class AttributePicker extends ArrowKeysMixin(LocalizeLabsElement(LitElement)) {
-	static get properties() {
-		return {
-			/* When true, the user can manually enter any attribute they wish. If false, they must match a value from the dropdown. */
-			allowFreeform: { type: Boolean, attribute: 'allow-freeform', reflect: true },
 
-			/* An array of strings available in the dropdown list */
-			assignableAttributes: { type: Array, attribute: 'assignable-attributes', reflect: true },
+	static properties = {
+		/* When true, the user can manually enter any attribute they wish. If false, they must match a value from the dropdown. */
+		allowFreeform: { type: Boolean, attribute: 'allow-freeform', reflect: true },
 
-			/* An array of strings representing the attributes currently selected in the picker */
-			attributeList: { type: Array, attribute: 'attribute-list', reflect: true },
+		/* An array of strings available in the dropdown list */
+		assignableAttributes: { type: Array, attribute: 'assignable-attributes', reflect: true },
 
-			/*
-				The text that will appear in the tooltip that informs a user that the state is invalid
-				The default value is: 'At least one attribute must be set'
-			*/
-			invalidTooltipText: { type: String, attribute: 'invalid-tooltip-text', reflect: true },
+		/* An array of strings representing the attributes currently selected in the picker */
+		attributeList: { type: Array, attribute: 'attribute-list', reflect: true },
 
-			/* Required. The label associated with the attribute picker for screen reader users */
-			label: { type: String, reflect: true },
+		/*
+			The text that will appear in the tooltip that informs a user that the state is invalid
+			The default value is: 'At least one attribute must be set'
+		*/
+		invalidTooltipText: { type: String, attribute: 'invalid-tooltip-text', reflect: true },
 
-			/* The maximum number of attributes permitted. */
-			limit: { type: Number, attribute: 'limit', reflect: true },
+		/* Required. The label associated with the attribute picker for screen reader users */
+		label: { type: String, reflect: true },
 
-			/* When true, an error state will appear if no attributes are set */
-			required: { type: Boolean, attribute: 'required', reflect: true },
+		/* The maximum number of attributes permitted. */
+		limit: { type: Number, attribute: 'limit', reflect: true },
 
-			/* Represents the index of the currently focused attribute. If no attribute is focused, equals -1 */
-			_activeAttributeIndex: { state: true },
+		/* When true, an error state will appear if no attributes are set */
+		required: { type: Boolean, attribute: 'required', reflect: true },
 
-			/* Represents the index of the currently focused dropdown list item. If no item is focused, equals -1 */
-			_dropdownIndex: { state: true },
+		/* Represents the index of the currently focused attribute. If no attribute is focused, equals -1 */
+		_activeAttributeIndex: { state: true },
 
-			/* When true, the user currently has focus within the component */
-			_hasFocus: { state: true },
+		/* Represents the index of the currently focused dropdown list item. If no item is focused, equals -1 */
+		_dropdownIndex: { state: true },
 
-			/* When true, the user has yet to lose focus for the first time, meaning the validation won't be shown until they've lost focus for the first time */
-			_initialFocus: { state: true },
+		/* When true, the user currently has focus within the component */
+		_hasFocus: { state: true },
 
-			/* When true, the user currently has focus within the input */
-			_inputFocused: { state: true },
+		/* When true, the user has yet to lose focus for the first time, meaning the validation won't be shown until they've lost focus for the first time */
+		_initialFocus: { state: true },
 
-			/* When true, the user has reached the limit of attributes that can be added */
-			_limitReached: { state: true },
+		/* When true, the user currently has focus within the input */
+		_inputFocused: { state: true },
 
-			/* The inner text of the input */
-			_text: { state: true }
-		};
-	}
+		/* When true, the user has reached the limit of attributes that can be added */
+		_limitReached: { state: true },
 
-	static get styles() {
-		return [inputStyles, css`
-			:host {
-				display: inline-block;
-				font-size: 0.8rem;
-				width: 100%;
-			}
-			:host:disabled {
-				opacity: 0.5;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-attribute-picker-container {
-				padding: 5px;
-			}
-			.d2l-attribute-picker-container:hover,
-			.d2l-attribute-picker-container:focus-within {
-				padding: 4px;
-			}
-			.d2l-attribute-picker-container:focus-within {
-				border: 2px solid var(--d2l-color-celestine);
-			}
-			[aria-invalid="true"].d2l-attribute-picker-container:focus-within {
-				border-color: var(--d2l-color-cinnabar);
-			}
-			.d2l-attribute-picker-content {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0.2rem;
-			}
-			.d2l-attribute-picker-attribute {
-				height: 1.55rem;
-			}
-			.d2l-attribute-picker-attribute:focus-visible {
-				outline: none;
-			}
-			.d2l-attribute-picker-input {
-				background: transparent;
-				border: none;
-				box-shadow: none;
-				box-sizing: border-box;
-				flex-grow: 1;
-				font-family: inherit;
-				font-size: inherit;
-				min-height: 1.55rem;
-				outline: none;
-				padding: 0 !important;
-				width: 4rem;
-			}
-			.d2l-attribute-list {
-				background-color: white;
-				border: 1px solid var(--d2l-color-gypsum);
-				border-radius: 0.3rem;
-				max-height: 7.8rem;
-				overflow-y: auto;
-				padding-left: 0;
-				text-overflow: ellipsis;
-			}
-			.d2l-attribute-picker-li {
-				cursor: pointer;
-				margin: 0;
-				padding: 0.4rem 6rem 0.4rem 0.6rem;
-			}
-			.d2l-attribute-picker-li[aria-selected="true"] {
-				background-color: var(--d2l-color-celestine-plus-2);
-				color: var(--d2l-color-celestine);
-			}
-			.d2l-attribute-picker-absolute-container {
-				margin: 0 0.3rem 0 -0.3rem;
-				position: absolute;
-				width: 100%;
-				z-index: 1;
-			}
-			.d2l-input-text-invalid-icon {
-				background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDxwYXRoIGZpbGw9IiNGRkYiIGQ9Ik0wIDBoMjJ2MjJIMHoiLz4KICAgIDxwYXRoIGQ9Ik0xOC44NjQgMTYuNDdMMTIuNjIzIDMuOTg5YTEuNzgzIDEuNzgzIDAgMDAtMy4xOTIgMEwzLjE4OSAxNi40N2ExLjc2MSAxLjc2MSAwIDAwLjA4IDEuNzNjLjMyNS41MjUuODk4Ljc5OCAxLjUxNi43OTloMTIuNDgzYy42MTggMCAxLjE5Mi0uMjczIDEuNTE2LS44LjIzNy0uMzM1LjI2NS0xLjM3LjA4LTEuNzN6IiBmaWxsPSIjQ0QyMDI2IiBmaWxsLXJ1bGU9Im5vbnplcm8iLz4KICAgIDxwYXRoIGQ9Ik0xMS4wMjcgMTcuMjY0YTEuMzM3IDEuMzM3IDAgMTEwLTIuNjc1IDEuMzM3IDEuMzM3IDAgMDEwIDIuNjc1ek0xMS45IDEyLjk4YS44OTIuODkyIDAgMDEtMS43NDcgMEw5LjI3IDguNTJhLjg5Mi44OTIgMCAwMS44NzQtMS4wNjRoMS43NjhhLjg5Mi44OTIgMCAwMS44NzQgMS4wNjVsLS44ODYgNC40NTh6IiBmaWxsPSIjRkZGIi8+CiAgPC9nPgo8L3N2Zz4K");
-				display: flex;
-				height: 22px;
-				inset-inline-end: 8px;
-				position: absolute;
-				top: 50%;
-				transform: translateY(-50%);
-				width: 22px;
-			}
-		`];
-	}
+		/* The inner text of the input */
+		_text: { state: true }
+	};
+
+	static styles = [inputStyles, css`
+		:host {
+			display: inline-block;
+			font-size: 0.8rem;
+			width: 100%;
+		}
+		:host:disabled {
+			opacity: 0.5;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-attribute-picker-container {
+			padding: 5px;
+		}
+		.d2l-attribute-picker-container:hover,
+		.d2l-attribute-picker-container:focus-within {
+			padding: 4px;
+		}
+		.d2l-attribute-picker-container:focus-within {
+			border: 2px solid var(--d2l-color-celestine);
+		}
+		[aria-invalid="true"].d2l-attribute-picker-container:focus-within {
+			border-color: var(--d2l-color-cinnabar);
+		}
+		.d2l-attribute-picker-content {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.2rem;
+		}
+		.d2l-attribute-picker-attribute {
+			height: 1.55rem;
+		}
+		.d2l-attribute-picker-attribute:focus-visible {
+			outline: none;
+		}
+		.d2l-attribute-picker-input {
+			background: transparent;
+			border: none;
+			box-shadow: none;
+			box-sizing: border-box;
+			flex-grow: 1;
+			font-family: inherit;
+			font-size: inherit;
+			min-height: 1.55rem;
+			outline: none;
+			padding: 0 !important;
+			width: 4rem;
+		}
+		.d2l-attribute-list {
+			background-color: white;
+			border: 1px solid var(--d2l-color-gypsum);
+			border-radius: 0.3rem;
+			max-height: 7.8rem;
+			overflow-y: auto;
+			padding-left: 0;
+			text-overflow: ellipsis;
+		}
+		.d2l-attribute-picker-li {
+			cursor: pointer;
+			margin: 0;
+			padding: 0.4rem 6rem 0.4rem 0.6rem;
+		}
+		.d2l-attribute-picker-li[aria-selected="true"] {
+			background-color: var(--d2l-color-celestine-plus-2);
+			color: var(--d2l-color-celestine);
+		}
+		.d2l-attribute-picker-absolute-container {
+			margin: 0 0.3rem 0 -0.3rem;
+			position: absolute;
+			width: 100%;
+			z-index: 1;
+		}
+		.d2l-input-text-invalid-icon {
+			background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDxwYXRoIGZpbGw9IiNGRkYiIGQ9Ik0wIDBoMjJ2MjJIMHoiLz4KICAgIDxwYXRoIGQ9Ik0xOC44NjQgMTYuNDdMMTIuNjIzIDMuOTg5YTEuNzgzIDEuNzgzIDAgMDAtMy4xOTIgMEwzLjE4OSAxNi40N2ExLjc2MSAxLjc2MSAwIDAwLjA4IDEuNzNjLjMyNS41MjUuODk4Ljc5OCAxLjUxNi43OTloMTIuNDgzYy42MTggMCAxLjE5Mi0uMjczIDEuNTE2LS44LjIzNy0uMzM1LjI2NS0xLjM3LjA4LTEuNzN6IiBmaWxsPSIjQ0QyMDI2IiBmaWxsLXJ1bGU9Im5vbnplcm8iLz4KICAgIDxwYXRoIGQ9Ik0xMS4wMjcgMTcuMjY0YTEuMzM3IDEuMzM3IDAgMTEwLTIuNjc1IDEuMzM3IDEuMzM3IDAgMDEwIDIuNjc1ek0xMS45IDEyLjk4YS44OTIuODkyIDAgMDEtMS43NDcgMEw5LjI3IDguNTJhLjg5Mi44OTIgMCAwMS44NzQtMS4wNjRoMS43NjhhLjg5Mi44OTIgMCAwMS44NzQgMS4wNjVsLS44ODYgNC40NTh6IiBmaWxsPSIjRkZGIi8+CiAgPC9nPgo8L3N2Zz4K");
+			display: flex;
+			height: 22px;
+			inset-inline-end: 8px;
+			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 22px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/card-overlay/card-overlay.js
+++ b/src/components/card-overlay/card-overlay.js
@@ -4,61 +4,59 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 
 class CardOverlay extends SkeletonMixin(LitElement) {
 
-	static get styles() {
-		return [super.styles, bodyStandardStyles, css`
-			:host {
-				display: block;
-				left: 0;
-				position: absolute;
-				top: 0;
-			}
-			:host([skeleton]) {
-				height: 100%;
-				width: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-insights-card-overlay-container {
-				background-color: white;
-				border-radius: 15px;
-				display: flex;
-				flex-direction: column;
-				height: calc(100% - 20px);
-				justify-content: center;
-				padding-left: 7px;
-				padding-top: 20px;
-				width: calc(100% - 28px);
-			}
-			.d2l-insights-card-overlay-title {
-				margin-left: 15px;
-				margin-right: 15px;
-				margin-top: 10px;
-				width: 100%;
-			}
-			.d2l-insights-card-overlay-body {
-				align-items: center;
-				display: flex;
-				height: 100%;
-				margin-bottom: 25px;
-			}
-			.d2l-insights-card-overlay-body > div {
-				flex-shrink: 0;
-				height: 70px;
-				margin: 0 15px;
-				width: 70px;
-			}
-			.d2l-insights-card-overlay-message {
-				display: inline-block;
-				font-size: 14px;
-				line-height: 1rem;
-				margin: 10px;
-				margin-left: 5px;
-				margin-right: 0;
-				vertical-align: middle;
-			}
-		`];
-	}
+	static styles = [super.styles, bodyStandardStyles, css`
+		:host {
+			display: block;
+			left: 0;
+			position: absolute;
+			top: 0;
+		}
+		:host([skeleton]) {
+			height: 100%;
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-insights-card-overlay-container {
+			background-color: white;
+			border-radius: 15px;
+			display: flex;
+			flex-direction: column;
+			height: calc(100% - 20px);
+			justify-content: center;
+			padding-left: 7px;
+			padding-top: 20px;
+			width: calc(100% - 28px);
+		}
+		.d2l-insights-card-overlay-title {
+			margin-left: 15px;
+			margin-right: 15px;
+			margin-top: 10px;
+			width: 100%;
+		}
+		.d2l-insights-card-overlay-body {
+			align-items: center;
+			display: flex;
+			height: 100%;
+			margin-bottom: 25px;
+		}
+		.d2l-insights-card-overlay-body > div {
+			flex-shrink: 0;
+			height: 70px;
+			margin: 0 15px;
+			width: 70px;
+		}
+		.d2l-insights-card-overlay-message {
+			display: inline-block;
+			font-size: 14px;
+			line-height: 1rem;
+			margin: 10px;
+			margin-left: 5px;
+			margin-right: 0;
+			vertical-align: middle;
+		}
+	`];
 
 	render() {
 		if (!this.skeleton) {

--- a/src/components/checkbox-drawer/checkbox-drawer.js
+++ b/src/components/checkbox-drawer/checkbox-drawer.js
@@ -10,47 +10,43 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 
 class CheckboxDrawer extends LocalizeLabsElement(SkeletonMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			checked: { type: Boolean },
-			description: { type: String },
-			disabled: { type: Boolean },
-			disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
-			label: { type: String },
-			readOnly: { type: Boolean, attribute: 'read-only' },
-			_expandCollapseBusy: { state: true }
-		};
-	}
+	static properties = {
+		checked: { type: Boolean },
+		description: { type: String },
+		disabled: { type: Boolean },
+		disabledTooltip: { type: String, attribute: 'disabled-tooltip' },
+		label: { type: String },
+		readOnly: { type: Boolean, attribute: 'read-only' },
+		_expandCollapseBusy: { state: true }
+	};
 
-	static get styles() {
-		return [super.styles, bodyCompactStyles, css`
-			:host {
-				display: block;
-			}
+	static styles = [super.styles, bodyCompactStyles, css`
+		:host {
+			display: block;
+		}
 
-			.d2l-input-checkbox {
-				margin-bottom: 0;
-			}
+		.d2l-input-checkbox {
+			margin-bottom: 0;
+		}
 
-			.d2l-input-checkbox-description {
-				color: var(--d2l-color-tungsten);
-				font-size: 0.7rem;
-				width: fit-content;
-			}
+		.d2l-input-checkbox-description {
+			color: var(--d2l-color-tungsten);
+			font-size: 0.7rem;
+			width: fit-content;
+		}
 
-			.d2l-checkbox-content-margin {
-				margin-top: 18px;
-			}
+		.d2l-checkbox-content-margin {
+			margin-top: 18px;
+		}
 
-			.d2l-input-read-only-label {
-				display: inline-block;
-				margin-left: 0.5rem;
-			}
-			.d2l-input-read-only-spacer {
-				padding-inline-start: 1.7rem;
-			}
-		`];
-	}
+		.d2l-input-read-only-label {
+			display: inline-block;
+			margin-left: 0.5rem;
+		}
+		.d2l-input-read-only-spacer {
+			padding-inline-start: 1.7rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/community/community-base.js
+++ b/src/components/community/community-base.js
@@ -3,11 +3,9 @@ import { LanguageListenerController } from '../../controllers/language-listener/
 
 export const CommunityBase = (superClass) => class CommunityBaseMixin extends superClass {
 
-	static get properties() {
-		return {
-			articleMap: { attribute: 'article-map', type: Object }
-		};
-	}
+	static properties = {
+		articleMap: { attribute: 'article-map', type: Object }
+	};
 
 	constructor() {
 		super();

--- a/src/components/community/community-button.js
+++ b/src/components/community/community-button.js
@@ -4,11 +4,9 @@ import { CommunityBase } from './community-base.js';
 
 class CommunityLink extends CommunityBase(LitElement) {
 
-	static get properties() {
-		return {
-			text: { type: String },
-		};
-	}
+	static properties = {
+		text: { type: String },
+	};
 
 	render() {
 		return html`<d2l-button-subtle

--- a/src/components/community/community-link.js
+++ b/src/components/community/community-link.js
@@ -4,12 +4,10 @@ import { CommunityBase } from './community-base.js';
 
 class CommunityLink extends CommunityBase(LitElement) {
 
-	static get properties() {
-		return {
-			text: { type: String },
-			small: { type: Boolean }
-		};
-	}
+	static properties = {
+		text: { type: String },
+		small: { type: Boolean }
+	};
 
 	render() {
 		return html`<d2l-link target="_blank" href="${this.communityArticleDirective(this.langController.language)}" ?small=${this.small} >${this.text}</d2l-link>`;

--- a/src/components/file-uploader/file-uploader.js
+++ b/src/components/file-uploader/file-uploader.js
@@ -6,177 +6,174 @@ import { FocusMixin } from '@brightspace-ui/core/mixins/focus/focus-mixin.js';
 import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 class FileUploader extends FocusMixin(LocalizeLabsElement(LitElement)) {
-	static get properties() {
-		return {
-			/**
-			 * When set, displays a feedback message to the user. Used in conjunction with `feedback-type`.
-			 */
-			feedback: { type: String, reflect: true },
-			/**
-			 * The type of feedback to display. One of: "error", "warning"
-			 */
-			feedbackType: { type: String, attribute: 'feedback-type', reflect: true },
-			/**
-			 * A descriptive label to associate with the file input. Should
-			 * be unique enough to distinguish the input from others on the page.
-			 */
-			label: { type: String },
-			/**
-			 * Whether multiple files can be uploaded.
-			 */
-			multiple: { type: Boolean, reflect: true },
-			/**
-			 * Collection of uploaded files, as [File](https://developer.mozilla.org/en-US/docs/Web/API/File) objects.
-			 */
-			_files: { type: Object },
-			/**
-			 * Whether a file is currently being dragged over the document.
-			 */
-			_fileDragOver: { type: Boolean, attribute: '_file-drag-over', reflect: true },
-			_inputFocus: { type: Boolean }
-		};
-	}
 
-	static get styles() {
-		return css`
-			:host {
-				box-sizing: border-box;
-				display: block;
-				max-width: 27rem;
-			}
-			:host([feedback-type="warning"]) {
-				--d2l-file-uploader-feedback-color: var(--d2l-color-feedback-warning);
-			}
-			:host([feedback-type="error"]) {
-				--d2l-file-uploader-feedback-color: var(--d2l-color-feedback-error);
-			}
+	static properties = {
+		/**
+		 * When set, displays a feedback message to the user. Used in conjunction with `feedback-type`.
+		 */
+		feedback: { type: String, reflect: true },
+		/**
+		 * The type of feedback to display. One of: "error", "warning"
+		 */
+		feedbackType: { type: String, attribute: 'feedback-type', reflect: true },
+		/**
+		 * A descriptive label to associate with the file input. Should
+		 * be unique enough to distinguish the input from others on the page.
+		 */
+		label: { type: String },
+		/**
+		 * Whether multiple files can be uploaded.
+		 */
+		multiple: { type: Boolean, reflect: true },
+		/**
+		 * Collection of uploaded files, as [File](https://developer.mozilla.org/en-US/docs/Web/API/File) objects.
+		 */
+		_files: { type: Object },
+		/**
+		 * Whether a file is currently being dragged over the document.
+		 */
+		_fileDragOver: { type: Boolean, attribute: '_file-drag-over', reflect: true },
+		_inputFocus: { type: Boolean }
+	};
 
-			.d2l-file-uploader-drop-zone {
-				border: 2px dashed var(--d2l-color-ferrite);
-				border-radius: 0.3rem;
-				padding: 1.5rem;
-				text-align: center;
-			}
+	static styles = css`
+		:host {
+			box-sizing: border-box;
+			display: block;
+			max-width: 27rem;
+		}
+		:host([feedback-type="warning"]) {
+			--d2l-file-uploader-feedback-color: var(--d2l-color-feedback-warning);
+		}
+		:host([feedback-type="error"]) {
+			--d2l-file-uploader-feedback-color: var(--d2l-color-feedback-error);
+		}
 
-			:host([_file-drag-over]) .d2l-file-uploader-drop-zone {
-				background-color: var(--d2l-color-celestine-plus-2);
-				border-color: var(--d2l-color-celestine);
-			}
+		.d2l-file-uploader-drop-zone {
+			border: 2px dashed var(--d2l-color-ferrite);
+			border-radius: 0.3rem;
+			padding: 1.5rem;
+			text-align: center;
+		}
 
-			.d2l-file-uploader-icon {
-				padding-bottom: 0.5rem;
-			}
+		:host([_file-drag-over]) .d2l-file-uploader-drop-zone {
+			background-color: var(--d2l-color-celestine-plus-2);
+			border-color: var(--d2l-color-celestine);
+		}
 
-			:host([_file-drag-over]) svg path {
-				fill: var(--d2l-color-celestine);
-			}
+		.d2l-file-uploader-icon {
+			padding-bottom: 0.5rem;
+		}
 
-			.d2l-file-uploader-input {
-				display: inline-block;
-				height: 100%;
-				left: 0;
+		:host([_file-drag-over]) svg path {
+			fill: var(--d2l-color-celestine);
+		}
+
+		.d2l-file-uploader-input {
+			display: inline-block;
+			height: 100%;
+			left: 0;
+			opacity: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+		}
+
+		.d2l-file-uploader-browse-label {
+			background: none;
+			border: none;
+			color: var(--d2l-color-celestine);
+			overflow: hidden;
+			padding-right: 0;
+			position: relative;
+		}
+		.d2l-file-uploader-browse-label:hover,
+		.d2l-file-uploader-browse-label-focus {
+			color: var(--d2l-color-celestine-minus-1);
+			text-decoration: underline;
+		}
+
+		.d2l-file-uploader-browse-files {
+			display: none;
+		}
+
+		.d2l-file-uploader-feedback {
+			-webkit-animation-duration: 0.7s;
+			animation-duration: 0.7s;
+			-webkit-animation-name: feedbackIn;
+			animation-name: feedbackIn;
+			border: 1px solid var(--d2l-color-mica);
+			border-left-color: var(--d2l-file-uploader-feedback-color);
+			border-left-width: 0.5rem;
+			border-radius: 0.3rem;
+			display: none;
+			margin-bottom: 1.5rem;
+			padding: 0.7rem 1rem 0.7rem;
+		}
+		:host(:dir(rtl)) > .d2l-file-uploader-feedback {
+			border-left-color: var(--d2l-color-mica);
+			border-left-width: 1px;
+			border-right-color: var(--d2l-file-uploader-feedback-color);
+			border-right-width: 0.5rem;
+		}
+		:host([feedback]) > .d2l-file-uploader-feedback {
+			display: block;
+		}
+
+		@keyframes feedbackIn {
+			0% {
+				max-height: 0.1rem;
 				opacity: 0;
-				position: absolute;
-				top: 0;
-				width: 100%;
 			}
+			20% {
+				opacity: 0;
+			}
+			80% {
+				max-height: 3rem;
+			}
+			100% {
+				opacity: 1;
+			}
+		}
 
-			.d2l-file-uploader-browse-label {
-				background: none;
-				border: none;
-				color: var(--d2l-color-celestine);
-				overflow: hidden;
-				padding-right: 0;
-				position: relative;
-			}
-			.d2l-file-uploader-browse-label:hover,
-			.d2l-file-uploader-browse-label-focus {
-				color: var(--d2l-color-celestine-minus-1);
-				text-decoration: underline;
+		@media (max-width: 992px) {
+
+			.d2l-file-uploader-input-container {
+				display: block;
+				margin-top: 0.8rem;
 			}
 
 			.d2l-file-uploader-browse-files {
+				display: inline;
+			}
+
+			.d2l-file-uploader-browse {
 				display: none;
 			}
 
-			.d2l-file-uploader-feedback {
-				-webkit-animation-duration: 0.7s;
-				animation-duration: 0.7s;
-				-webkit-animation-name: feedbackIn;
-				animation-name: feedbackIn;
-				border: 1px solid var(--d2l-color-mica);
-				border-left-color: var(--d2l-file-uploader-feedback-color);
-				border-left-width: 0.5rem;
+			.d2l-file-uploader-browse-label {
+				background-color: var(--d2l-color-celestine);
+				border-color: var(--d2l-color-celestine-minus-1);
 				border-radius: 0.3rem;
-				display: none;
-				margin-bottom: 1.5rem;
-				padding: 0.7rem 1rem 0.7rem;
-			}
-			:host(:dir(rtl)) > .d2l-file-uploader-feedback {
-				border-left-color: var(--d2l-color-mica);
-				border-left-width: 1px;
-				border-right-color: var(--d2l-file-uploader-feedback-color);
-				border-right-width: 0.5rem;
-			}
-			:host([feedback]) > .d2l-file-uploader-feedback {
-				display: block;
+				border-style: none;
+				color: #ffffff;
+				display: inline-block;
+				font-size: 0.7rem;
+				padding: 0.35rem 1.5rem;
 			}
 
-			@keyframes feedbackIn {
-				0% {
-					max-height: 0.1rem;
-					opacity: 0;
-				}
-				20% {
-					opacity: 0;
-				}
-				80% {
-					max-height: 3rem;
-				}
-				100% {
-					opacity: 1;
-				}
+			.d2l-file-uploader-browse-label:hover,
+			.d2l-file-uploader-browse-label-focus {
+				background-color: var(--d2l-color-celestine-minus-1);
+				color: #ffffff;
+				text-decoration: none;
+			}
+			.d2l-file-uploader-browse-label-focus {
+				box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
 			}
 
-			@media (max-width: 992px) {
-
-				.d2l-file-uploader-input-container {
-					display: block;
-					margin-top: 0.8rem;
-				}
-
-				.d2l-file-uploader-browse-files {
-					display: inline;
-				}
-
-				.d2l-file-uploader-browse {
-					display: none;
-				}
-
-				.d2l-file-uploader-browse-label {
-					background-color: var(--d2l-color-celestine);
-					border-color: var(--d2l-color-celestine-minus-1);
-					border-radius: 0.3rem;
-					border-style: none;
-					color: #ffffff;
-					display: inline-block;
-					font-size: 0.7rem;
-					padding: 0.35rem 1.5rem;
-				}
-
-				.d2l-file-uploader-browse-label:hover,
-				.d2l-file-uploader-browse-label-focus {
-					background-color: var(--d2l-color-celestine-minus-1);
-					color: #ffffff;
-					text-decoration: none;
-				}
-				.d2l-file-uploader-browse-label-focus {
-					box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--d2l-color-celestine);
-				}
-
-			}
-		`;
-	}
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/grade-result/grade-result-icon-button.js
+++ b/src/components/grade-result/grade-result-icon-button.js
@@ -3,12 +3,11 @@ import { html, LitElement } from 'lit';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 
 export class D2LGradeResultIconButton extends LitElement {
-	static get properties() {
-		return {
-			text: { type: String },
-			icon: { type: String },
-		};
-	}
+
+	static properties = {
+		text: { type: String },
+		icon: { type: String },
+	};
 
 	render() {
 		return html`

--- a/src/components/grade-result/grade-result-letter-score.js
+++ b/src/components/grade-result/grade-result-letter-score.js
@@ -8,29 +8,25 @@ import { selectStyles } from '@brightspace-ui/core/components/inputs/input-selec
  */
 export class D2LGradeResultLetterScore extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			availableOptions: { attribute: 'available-options', type: Object },
-			label: { type: String },
-			selectedOption: { attribute: 'selected-option', type: String },
-			readonly: { type: Boolean }
-		};
-	}
+	static properties = {
+		availableOptions: { attribute: 'available-options', type: Object },
+		label: { type: String },
+		selectedOption: { attribute: 'selected-option', type: String },
+		readonly: { type: Boolean }
+	};
 
-	static get styles() {
-		return [selectStyles, bodyStandardStyles, css`
-			.d2l-grade-result-letter-score-container {
-				width: 8rem;
-			}
-			.d2l-grade-result-letter-score-select {
-				width: 100%;
-			}
-			.d2l-grade-result-letter-score-score-read-only {
-				height: calc(2rem + 2px);
-				line-height: calc(2rem + 2px);
-			}
-		`];
-	}
+	static styles = [selectStyles, bodyStandardStyles, css`
+		.d2l-grade-result-letter-score-container {
+			width: 8rem;
+		}
+		.d2l-grade-result-letter-score-select {
+			width: 100%;
+		}
+		.d2l-grade-result-letter-score-score-read-only {
+			height: calc(2rem + 2px);
+			line-height: calc(2rem + 2px);
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/grade-result/grade-result-numeric-score.js
+++ b/src/components/grade-result/grade-result-numeric-score.js
@@ -18,35 +18,32 @@ const MIN_POSITIVE_GRADE = 0;
  * @fires d2l-grade-result-grade-change - Dispatched on the change of the grade for a gradeType="Numeric" grade.
  */
 export class D2LGradeResultNumericScore extends LocalizeLabsElement(LitElement) {
-	static get properties() {
-		return {
-			label: { type: String },
-			scoreNumerator: { attribute: 'score-numerator', type: Number, converter: numberConverter },
-			scoreDenominator: { attribute: 'score-denominator', type: Number },
-			readonly: { type: Boolean },
-			required: { type: Boolean },
-			allowNegativeScore: { attribute: 'allow-negative-score', type: Boolean },
-			showFlooredScoreWarning: { attribute: 'show-floored-score-warning', type: Boolean },
-		};
-	}
 
-	static get styles() {
-		return [bodyCompactStyles, bodyStandardStyles, css`
-			.d2l-grade-result-numeric-score-container {
-				align-items: center;
-				display: flex;
-				flex-direction: row;
-			}
-			.d2l-grade-result-numeric-score-score-read-only {
-				height: calc(2rem + 2px);
-				line-height: calc(2rem + 2px);
-				max-width: 5.25rem;
-			}
-			.d2l-grade-result-numeric-score-hint {
-				margin: 0 0.3rem;
-			}
-		`];
-	}
+	static properties = {
+		label: { type: String },
+		scoreNumerator: { attribute: 'score-numerator', type: Number, converter: numberConverter },
+		scoreDenominator: { attribute: 'score-denominator', type: Number },
+		readonly: { type: Boolean },
+		required: { type: Boolean },
+		allowNegativeScore: { attribute: 'allow-negative-score', type: Boolean },
+		showFlooredScoreWarning: { attribute: 'show-floored-score-warning', type: Boolean },
+	};
+
+	static styles = [bodyCompactStyles, bodyStandardStyles, css`
+		.d2l-grade-result-numeric-score-container {
+			align-items: center;
+			display: flex;
+			flex-direction: row;
+		}
+		.d2l-grade-result-numeric-score-score-read-only {
+			height: calc(2rem + 2px);
+			line-height: calc(2rem + 2px);
+			max-width: 5.25rem;
+		}
+		.d2l-grade-result-numeric-score-hint {
+			margin: 0 0.3rem;
+		}
+	`];
 
 	render() {
 		const roundedNumerator = isNaN(this.scoreNumerator) ? '' : Math.round((this.scoreNumerator + Number.EPSILON) * 100) / 100;

--- a/src/components/grade-result/grade-result-presentational.js
+++ b/src/components/grade-result/grade-result-presentational.js
@@ -20,143 +20,140 @@ const numberConverter = {
  * @fires d2l-grade-result-reports-button-click - Dispatched when the reports button is clicked.
  */
 export class D2LGradeResultPresentational extends LocalizeLabsElement(LitElement) {
-	static get properties() {
-		return {
-			/**
-			 * Set to true if negative scores can be entered
-			 * @type {boolean}
-			 */
-			allowNegativeScore: { attribute: 'allow-negative-score', type: Boolean },
-			/**
-			 * This property will substitute the stock text on the "Clear Manual Override" button
-			 * @type {string}
-			 */
-			customManualOverrideClearText: { attribute: 'custom-manual-override-clear-text', type: String },
-			/**
-			 * @type {boolean}
-			 */
-			displayStudentGradePreview: { type: Boolean, attribute: 'display-student-grade-preview' },
-			/**
-			 * The text that is inside of the tooltip when hovering over the grades button
-			 * @type {string}
-			 */
-			gradeButtonTooltip: { attribute: 'grade-button-tooltip', type: String },
-			/**
-			 * Specifies the type of grade that the component is meant to render
-			 * @type {'Numeric'|'LetterGrade'}
-			 */
-			gradeType: { attribute: 'grade-type', type: String },
-			/**
-			 * This property will hide the "Overall Grade" title above the component
-			 * @type {boolean}
-			 */
-			hideTitle: { attribute: 'hide-title', type: Boolean },
-			/**
-			 * Determines whether the grades icon button is rendered
-			 * @type {boolean}
-			 */
-			includeGradeButton: { attribute: 'include-grade-button', type: Boolean },
-			/**
-			 * Determines whether the reports icon button is rendered
-			 * @type {boolean}
-			 */
-			includeReportsButton: { attribute: 'include-reports-button', type: Boolean },
-			/**
-			 * This property sets the label that will be used inside the aria-label and validation error tooltips
-			 * @type {string}
-			 */
-			inputLabelText: { attribute: 'input-label-text', type: String },
-			/**
-			 * Set to true if the user is currently manually overriding the grade. This will display the button to 'Clear Manual Override'.
-			 * @type {boolean}
-			 */
-			isManualOverrideActive: { attribute: 'is-manual-override-active', type: Boolean },
-			/**
-			 * @type {number}
-			 */
-			labelHeadingLevel: { attribute: 'label-heading-level', type: Number },
-			/**
-			 * The text that appears above the component
-			 * @type {string}
-			 */
-			labelText: { attribute: 'label-text', type: String },
-			/**
-			 * A dictionary where the key is a unique id and the value is an object containing the LetterGrade text and the PercentStart
-			 * @type {object}
-			 */
-			letterGradeOptions: { attribute: 'letter-grade-options', type: Object },
-			/**
-			 * Set to true if the user does not have permissions to edit the grade
-			 * @type {boolean}
-			 */
-			readonly: { type: Boolean },
-			/**
-			 * The text that is inside of the tooltip when hovering over the reports button
-			 * @type {string}
-			 */
-			reportsButtonTooltip: { attribute: 'reports-button-tooltip', type: String },
-			/**
-			 * Set to true if an undefined/blank grade is not considered valid
-			 * @type {boolean}
-			 */
-			required: { type: Boolean },
-			/**
-			 * The denominator of the numeric score that is given
-			 * @type {number}
-			 */
-			scoreDenominator: { attribute: 'score-denominator', type: Number },
-			/**
-			 * The numerator of the numeric score that is given
-			 * @type {number}
-			 */
-			scoreNumerator: { attribute: 'score-numerator', type: Number, converter: numberConverter },
-			/**
-			 * The current selected letter grade of the options given
-			 * @type {string}
-			 */
-			selectedLetterGrade: { attribute: 'selected-letter-grade', type: String },
-			/**
-			 * Set to true if displaying a negative grade that has been floored at 0
-			 * @type {boolean}
-			 */
-			showFlooredScoreWarning: { attribute: 'show-floored-score-warning', type: Boolean },
-			/**
-			 * This property will show the given text under the title
-			 * @type {string}
-			 */
-			subtitleText: { attribute: 'subtitle-text', type: String },
-			/**
-			 * @type {object}
-			 */
-			studentGradePreview: { type: Object, attribute: 'student-grade-preview' },
-		};
-	}
 
-	static get styles() {
-		return [ bodySmallStyles, labelStyles, css`
-			.d2l-grade-result-presentational-container {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0 0.9rem;
-			}
-			.d2l-grade-result-presentational-score-container {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0.3rem;
-			}
-			.d2l-grade-result-manual-override-clear {
-				margin-top: 0.3rem;
-			}
-			.d2l-label-text {
-				line-height: 1.6rem;
-				margin-bottom: 0.4rem;
-			}
-			.d2l-grade-result-presentational-subtitle {
-				font-weight: bold;
-				margin-top: -4px;
-			}
-		`];
-	}
+	static properties = {
+		/**
+		 * Set to true if negative scores can be entered
+		 * @type {boolean}
+		 */
+		allowNegativeScore: { attribute: 'allow-negative-score', type: Boolean },
+		/**
+		 * This property will substitute the stock text on the "Clear Manual Override" button
+		 * @type {string}
+		 */
+		customManualOverrideClearText: { attribute: 'custom-manual-override-clear-text', type: String },
+		/**
+		 * @type {boolean}
+		 */
+		displayStudentGradePreview: { type: Boolean, attribute: 'display-student-grade-preview' },
+		/**
+		 * The text that is inside of the tooltip when hovering over the grades button
+		 * @type {string}
+		 */
+		gradeButtonTooltip: { attribute: 'grade-button-tooltip', type: String },
+		/**
+		 * Specifies the type of grade that the component is meant to render
+		 * @type {'Numeric'|'LetterGrade'}
+		 */
+		gradeType: { attribute: 'grade-type', type: String },
+		/**
+		 * This property will hide the "Overall Grade" title above the component
+		 * @type {boolean}
+		 */
+		hideTitle: { attribute: 'hide-title', type: Boolean },
+		/**
+		 * Determines whether the grades icon button is rendered
+		 * @type {boolean}
+		 */
+		includeGradeButton: { attribute: 'include-grade-button', type: Boolean },
+		/**
+		 * Determines whether the reports icon button is rendered
+		 * @type {boolean}
+		 */
+		includeReportsButton: { attribute: 'include-reports-button', type: Boolean },
+		/**
+		 * This property sets the label that will be used inside the aria-label and validation error tooltips
+		 * @type {string}
+		 */
+		inputLabelText: { attribute: 'input-label-text', type: String },
+		/**
+		 * Set to true if the user is currently manually overriding the grade. This will display the button to 'Clear Manual Override'.
+		 * @type {boolean}
+		 */
+		isManualOverrideActive: { attribute: 'is-manual-override-active', type: Boolean },
+		/**
+		 * @type {number}
+		 */
+		labelHeadingLevel: { attribute: 'label-heading-level', type: Number },
+		/**
+		 * The text that appears above the component
+		 * @type {string}
+		 */
+		labelText: { attribute: 'label-text', type: String },
+		/**
+		 * A dictionary where the key is a unique id and the value is an object containing the LetterGrade text and the PercentStart
+		 * @type {object}
+		 */
+		letterGradeOptions: { attribute: 'letter-grade-options', type: Object },
+		/**
+		 * Set to true if the user does not have permissions to edit the grade
+		 * @type {boolean}
+		 */
+		readonly: { type: Boolean },
+		/**
+		 * The text that is inside of the tooltip when hovering over the reports button
+		 * @type {string}
+		 */
+		reportsButtonTooltip: { attribute: 'reports-button-tooltip', type: String },
+		/**
+		 * Set to true if an undefined/blank grade is not considered valid
+		 * @type {boolean}
+		 */
+		required: { type: Boolean },
+		/**
+		 * The denominator of the numeric score that is given
+		 * @type {number}
+		 */
+		scoreDenominator: { attribute: 'score-denominator', type: Number },
+		/**
+		 * The numerator of the numeric score that is given
+		 * @type {number}
+		 */
+		scoreNumerator: { attribute: 'score-numerator', type: Number, converter: numberConverter },
+		/**
+		 * The current selected letter grade of the options given
+		 * @type {string}
+		 */
+		selectedLetterGrade: { attribute: 'selected-letter-grade', type: String },
+		/**
+		 * Set to true if displaying a negative grade that has been floored at 0
+		 * @type {boolean}
+		 */
+		showFlooredScoreWarning: { attribute: 'show-floored-score-warning', type: Boolean },
+		/**
+		 * This property will show the given text under the title
+		 * @type {string}
+		 */
+		subtitleText: { attribute: 'subtitle-text', type: String },
+		/**
+		 * @type {object}
+		 */
+		studentGradePreview: { type: Object, attribute: 'student-grade-preview' },
+	};
+
+	static styles = [bodySmallStyles, labelStyles, css`
+		.d2l-grade-result-presentational-container {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0 0.9rem;
+		}
+		.d2l-grade-result-presentational-score-container {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.3rem;
+		}
+		.d2l-grade-result-manual-override-clear {
+			margin-top: 0.3rem;
+		}
+		.d2l-label-text {
+			line-height: 1.6rem;
+			margin-bottom: 0.4rem;
+		}
+		.d2l-grade-result-presentational-subtitle {
+			font-weight: bold;
+			margin-top: -4px;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/grade-result/grade-result-student-grade-preview.js
+++ b/src/components/grade-result/grade-result-student-grade-preview.js
@@ -12,49 +12,45 @@ const previewOptions = {
 
 export class D2LGradeResultStudentGradePreview extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			hideLabel: {
-				type: Boolean,
-				attribute: 'hide-label'
-			},
-			outOf: {
-				type: Number,
-				attribute: 'out-of'
-			},
-			studentGradePreview: {
-				type: Object,
-				attribute: 'student-grade-preview'
-			}
-		};
-	}
+	static properties = {
+		hideLabel: {
+			type: Boolean,
+			attribute: 'hide-label'
+		},
+		outOf: {
+			type: Number,
+			attribute: 'out-of'
+		},
+		studentGradePreview: {
+			type: Object,
+			attribute: 'student-grade-preview'
+		}
+	};
 
-	static get styles() {
-		return [bodySmallStyles, bodyCompactStyles, labelStyles, css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-grade-result-student-grade-preview-container {
-				align-items: center;
-				display: flex;
-				flex-direction: row;
-				gap: 0.5rem;
-				min-height: calc(2rem + 2px);
-			}
-			.d2l-grade-result-student-grade-preview-colour {
-				border-radius: 6px;
-				height: 0.9rem;
-				width: 0.9rem;
-			}
-			.d2l-label-text {
-				line-height: 1.6rem;
-				margin-bottom: 0.4rem;
-			}
-		`];
-	}
+	static styles = [bodySmallStyles, bodyCompactStyles, labelStyles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.d2l-grade-result-student-grade-preview-container {
+			align-items: center;
+			display: flex;
+			flex-direction: row;
+			gap: 0.5rem;
+			min-height: calc(2rem + 2px);
+		}
+		.d2l-grade-result-student-grade-preview-colour {
+			border-radius: 6px;
+			height: 0.9rem;
+			width: 0.9rem;
+		}
+		.d2l-label-text {
+			line-height: 1.6rem;
+			margin-bottom: 0.4rem;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/media-player/media-player-audio-bars.js
+++ b/src/components/media-player/media-player-audio-bars.js
@@ -61,41 +61,38 @@ const AUDIO_BAR_WIDTH_PX = AUDIO_BAR_WIDTH_REM * PX_PER_REM;
 const AUDIO_BAR_HORIZONTAL_MARGIN_PX = AUDIO_BAR_HORIZONTAL_MARGIN_REM * PX_PER_REM;
 
 class MediaPlayerAudioBars extends LitElement {
-	static get properties() {
-		return {
-			playing: { type: Boolean },
-			_visibleAudioBars: { type: Array, attribute: false },
-		};
-	}
 
-	static get styles() {
-		return css`
-			:host {
-				width: 100%;
-			}
+	static properties = {
+		playing: { type: Boolean },
+		_visibleAudioBars: { type: Array, attribute: false },
+	};
 
-			#d2l-labs-media-player-audio-bars-row {
-				align-items: center;
-				display: flex;
-				flex-direction: row;
-				height: 100%;
-				justify-content: center;
-			}
+	static styles = css`
+		:host {
+			width: 100%;
+		}
 
-			#d2l-labs-media-player-audio-bar-container {
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-			}
+		#d2l-labs-media-player-audio-bars-row {
+			align-items: center;
+			display: flex;
+			flex-direction: row;
+			height: 100%;
+			justify-content: center;
+		}
 
-			.d2l-labs-media-player-audio-bar {
-				border-top-left-radius: 0.075rem;
-				border-top-right-radius: 0.075rem;
-				margin: 0 ${AUDIO_BAR_HORIZONTAL_MARGIN_REM}rem;
-				width: ${AUDIO_BAR_WIDTH_REM}rem;
-			}
-`;
-	}
+		#d2l-labs-media-player-audio-bar-container {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+		}
+
+		.d2l-labs-media-player-audio-bar {
+			border-top-left-radius: 0.075rem;
+			border-top-right-radius: 0.075rem;
+			margin: 0 ${AUDIO_BAR_HORIZONTAL_MARGIN_REM}rem;
+			width: ${AUDIO_BAR_WIDTH_REM}rem;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/media-player/media-player.js
+++ b/src/components/media-player/media-player.js
@@ -77,549 +77,545 @@ const tryParseUrlExpiry = url => {
 
 class MediaPlayer extends LocalizeLabsElement(RtlMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			allowDownload: { type: Boolean, attribute: 'allow-download', reflect: true },
-			autoplay: { type: Boolean },
-			crossorigin: { type: String },
-			downloadFilename: { type: String, attribute: 'download-filename' },
-			durationHint: { type: Number, attribute: 'duration-hint' },
-			hideCaptionsSelection: { type: Boolean, attribute: 'hide-captions-selection' },
-			hideSeekBar: { type: Boolean, attribute: 'hide-seek-bar' },
-			loop: { type: Boolean },
-			mediaType: { type: String, attribute: 'media-type' },
-			metadata: { type: Object },
-			poster: { type: String },
-			src: { type: String },
-			thumbnails: { type: String },
-			disableSetPreferences: { type: Boolean, attribute: 'disable-set-preferences' },
-			transcriptViewerOn: { type: Boolean, attribute: 'transcript-viewer-on' },
-			playInView: { type: Boolean, attribute: 'play-in-view' },
-			_chapters: { type: Array, attribute: false },
-			_currentTime: { type: Number, attribute: false },
-			_duration: { type: Number, attribute: false },
-			_heightPixels: { type: Number, attribute: false },
-			_hoverTime: { type: Number, attribute: false },
-			_hovering: { type: Boolean, attribute: false },
-			_loading: { type: Boolean, attribute: false },
-			_maintainHeight: { type: Number, attribute: false },
-			_mediaContainerAspectRatio: { type: Object, attribute: false },
-			_message: { type: Object, attribute: false },
-			_muted: { type: Boolean, attribute: false },
-			_playing: { type: Boolean, attribute: false },
-			_posterVisible: { type: Boolean, attribute: false },
-			_recentlyShowedCustomControls: { type: Boolean, attribute: false },
-			_searchResults: { type: Array, attribute: false },
-			_selectedQuality: { type: String, attribute: false },
-			_selectedSpeed: { type: String, attribute: false },
-			_selectedTrackIdentifier: { type: Object, attribute: false },
-			_sources: { type: Object, attribute: false },
-			_thumbnailsImage: { type: Object, attribute: false },
-			_timelinePreviewOffset: { type: Number, attribute: false },
-			_trackFontSizeRem: { type: Number, attribute: false },
-			_timeFontSizeRem: { type: Number, attribute: false },
-			_trackText: { type: String, attribute: false },
-			_tracks: { type: Array, attribute: false },
-			_usingVolumeContainer: { type: Boolean, attribute: false },
-			_volume: { type: Number, attribute: false },
-		};
-	}
+	static properties = {
+		allowDownload: { type: Boolean, attribute: 'allow-download', reflect: true },
+		autoplay: { type: Boolean },
+		crossorigin: { type: String },
+		downloadFilename: { type: String, attribute: 'download-filename' },
+		durationHint: { type: Number, attribute: 'duration-hint' },
+		hideCaptionsSelection: { type: Boolean, attribute: 'hide-captions-selection' },
+		hideSeekBar: { type: Boolean, attribute: 'hide-seek-bar' },
+		loop: { type: Boolean },
+		mediaType: { type: String, attribute: 'media-type' },
+		metadata: { type: Object },
+		poster: { type: String },
+		src: { type: String },
+		thumbnails: { type: String },
+		disableSetPreferences: { type: Boolean, attribute: 'disable-set-preferences' },
+		transcriptViewerOn: { type: Boolean, attribute: 'transcript-viewer-on' },
+		playInView: { type: Boolean, attribute: 'play-in-view' },
+		_chapters: { type: Array, attribute: false },
+		_currentTime: { type: Number, attribute: false },
+		_duration: { type: Number, attribute: false },
+		_heightPixels: { type: Number, attribute: false },
+		_hoverTime: { type: Number, attribute: false },
+		_hovering: { type: Boolean, attribute: false },
+		_loading: { type: Boolean, attribute: false },
+		_maintainHeight: { type: Number, attribute: false },
+		_mediaContainerAspectRatio: { type: Object, attribute: false },
+		_message: { type: Object, attribute: false },
+		_muted: { type: Boolean, attribute: false },
+		_playing: { type: Boolean, attribute: false },
+		_posterVisible: { type: Boolean, attribute: false },
+		_recentlyShowedCustomControls: { type: Boolean, attribute: false },
+		_searchResults: { type: Array, attribute: false },
+		_selectedQuality: { type: String, attribute: false },
+		_selectedSpeed: { type: String, attribute: false },
+		_selectedTrackIdentifier: { type: Object, attribute: false },
+		_sources: { type: Object, attribute: false },
+		_thumbnailsImage: { type: Object, attribute: false },
+		_timelinePreviewOffset: { type: Number, attribute: false },
+		_trackFontSizeRem: { type: Number, attribute: false },
+		_timeFontSizeRem: { type: Number, attribute: false },
+		_trackText: { type: String, attribute: false },
+		_tracks: { type: Array, attribute: false },
+		_usingVolumeContainer: { type: Boolean, attribute: false },
+		_volume: { type: Number, attribute: false },
+	};
 
-	static get styles() {
-		return [ labelStyles, css`
-			:host {
-				display: block;
-				min-height: 140px;
-				position: relative;
-			}
+	static styles = [labelStyles, css`
+		:host {
+			display: block;
+			min-height: 140px;
+			position: relative;
+		}
 
-			:host([hidden]) {
-				display: none;
-			}
+		:host([hidden]) {
+			display: none;
+		}
 
-			#d2l-labs-media-player-media-container {
+		#d2l-labs-media-player-media-container {
+			align-items: center;
+			justify-content: center;
+			/* This max-height prevents the video from growing out of bounds and appearing cut off inside of ISF iframes */
+			max-height: 100vh;
+			overflow: hidden;
+			position: relative;
+			width: 100%;
+		}
+
+		.d2l-labs-media-player-type-is-audio {
+			background-color: #ffffff;
+		}
+
+		.d2l-labs-media-player-type-is-video {
+			background-color: #000000;
+			color: #ffffff;
+		}
+
+
+		#d2l-labs-media-player-video {
+			display: block;
+			height: 100%;
+			max-height: var(--d2l-labs-media-player-video-max-height, 100vh);
+			min-height: 100%;
+			position: relative;
+			width: 100%;
+		}
+
+		#d2l-labs-media-player-video-poster {
+			background-color: #000000;
+			cursor: pointer;
+			height: 100%;
+			object-fit: contain;
+			position: absolute;
+			width: 100%;
+			z-index: 1;
+		}
+
+		#d2l-labs-media-player-video-poster-play-button {
+			background-color: rgba(0, 0, 0, 0.69);
+			border: none;
+			border-radius: 50%;
+			cursor: pointer;
+			padding: 2em;
+			position: absolute;
+			z-index: 2;
+		}
+
+		#d2l-labs-media-player-video-poster-play-button[transcript] {
+			background-color: rgba(0, 0, 0, 0.69);
+			border: none;
+			border-radius: 50%;
+			cursor: pointer;
+			left: 10%;
+			padding: 2em;
+			position: absolute;
+			top: 10%;
+			transform: scale(0.5);
+			z-index: 2;
+		}
+
+
+		#d2l-labs-media-player-video-poster-play-button > d2l-icon {
+			color: #ffffff;
+		}
+
+		#d2l-labs-media-player-media-controls {
+			bottom: 0;
+			position: absolute;
+			transition: bottom 500ms ease;
+			width: 100%;
+			z-index: 2;
+		}
+
+		.d2l-labs-media-player-type-is-audio #d2l-labs-media-player-media-controls {
+			background-color: #ffffff;
+		}
+		.d2l-labs-media-player-type-is-video #d2l-labs-media-player-media-controls {
+			background-color: rgba(0, 0, 0, 0.69);
+		}
+
+		#d2l-labs-media-player-media-controls.d2l-labs-media-player-hidden {
+			bottom: -8rem;
+		}
+
+		#d2l-labs-media-player-seek-bar {
+			--d2l-knob-focus-color: #ffffff;
+			--d2l-knob-focus-size: 4px;
+			--d2l-knob-size: 16px;
+			--d2l-outer-knob-color: var(--d2l-color-celestine-plus-1);
+			--d2l-progress-border-radius: 0;
+			position: absolute;
+			top: -9px;
+			width: 100%;
+			z-index: 1;
+		}
+
+		#d2l-labs-media-player-seek-bar:focus {
+			--d2l-knob-box-shadow: 0 2px 6px 3px rgba(0, 0, 0, 1);
+		}
+
+		#d2l-labs-media-player-buttons {
+			align-items: center;
+			direction: ltr;
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			margin-left: 6px;
+		}
+
+		[dir="rtl"] #d2l-labs-media-player-buttons {
+			margin-left: 0;
+			margin-right: 6px;
+		}
+
+		.d2l-labs-media-player-flex-filler {
+			flex: auto;
+		}
+
+		d2l-button-icon {
+			--d2l-button-icon-min-height: 1.8rem;
+			--d2l-button-icon-min-width: 1.8rem;
+			margin: 6px 6px 6px 0;
+		}
+
+		#d2l-labs-media-player-time:hover {
+			cursor: auto;
+		}
+
+		#d2l-labs-media-player-volume-container {
+			position: relative;
+		}
+
+		#d2l-labs-media-player-volume-level-container {
+			bottom: calc(1.8rem + 6px);
+			height: 11px;
+			left: 0;
+			position: absolute;
+			width: 1.8rem;
+			z-index: 2;
+		}
+
+		#d2l-labs-media-player-volume-level-container.d2l-labs-media-player-hidden {
+			left: -10000px;
+		}
+
+		#d2l-labs-media-player-volume-level-background {
+			align-items: center;
+			background-color: rgba(0, 0, 0, 0.69);
+			border-radius: 0 0.3rem 0.3rem 0;
+			bottom: 4.55rem;
+			display: flex;
+			height: 1.8rem;
+			justify-content: center;
+			left: -2.7rem;
+			padding: 0 0.625rem;
+			position: relative;
+			width: 6rem;
+		}
+
+		#d2l-labs-media-player-volume-slider-container {
+			height: 100%;
+			width: 100%;
+		}
+
+		#d2l-labs-media-player-volume-slider {
+			--d2l-knob-focus-color: #ffffff;
+			--d2l-knob-focus-size: 0.25rem;
+			--d2l-knob-size: 0.8rem;
+			--d2l-outer-knob-color: var(--d2l-color-celestine-plus-1);
+			position: relative;
+			top: calc(0.5rem + 1px);
+		}
+
+		.d2l-labs-media-player-rotated {
+			transform: rotate(-90deg);
+		}
+
+		#d2l-labs-media-player-audio-bars-container {
+			align-items: center;
+			display: flex;
+			flex-wrap: nowrap;
+			height: 8.5rem;
+			justify-content: center;
+			left: calc(2.1rem + 6px);
+			position: absolute;
+			top: calc(50% - 5.125rem);
+			width: calc(100% - 4.2rem - 12px);
+		}
+
+		d2l-labs-media-player-audio-bars {
+			height: 2rem;
+		}
+
+		#d2l-labs-media-player-track-container {
+			align-items: center;
+			color: #ffffff;
+			display: flex;
+			justify-content: center;
+			overflow: hidden;
+			position: absolute;
+			text-align: center;
+			transition: bottom 500ms ease;
+			width: 100%;
+		}
+
+		@media screen and (min-width: 768px) {
+			#d2l-labs-media-player-track-container > div {
 				align-items: center;
+				display: flex;
 				justify-content: center;
-				/* This max-height prevents the video from growing out of bounds and appearing cut off inside of ISF iframes */
-				max-height: 100vh;
-				overflow: hidden;
-				position: relative;
-				width: 100%;
+				min-width: ${MIN_TRACK_WIDTH_PX}px;
+				width: 50%;
 			}
+		}
 
-			.d2l-labs-media-player-type-is-audio {
-				background-color: #ffffff;
-			}
-
-			.d2l-labs-media-player-type-is-video {
-				background-color: #000000;
-				color: #ffffff;
-			}
-
-
-			#d2l-labs-media-player-video {
-				display: block;
-				height: 100%;
-				max-height: var(--d2l-labs-media-player-video-max-height, 100vh);
-				min-height: 100%;
-				position: relative;
-				width: 100%;
-			}
-
-			#d2l-labs-media-player-video-poster {
-				background-color: #000000;
-				cursor: pointer;
-				height: 100%;
-				object-fit: contain;
-				position: absolute;
-				width: 100%;
-				z-index: 1;
-			}
-
-			#d2l-labs-media-player-video-poster-play-button {
-				background-color: rgba(0, 0, 0, 0.69);
-				border: none;
-				border-radius: 50%;
-				cursor: pointer;
-				padding: 2em;
-				position: absolute;
-				z-index: 2;
-			}
-
-			#d2l-labs-media-player-video-poster-play-button[transcript] {
-				background-color: rgba(0, 0, 0, 0.69);
-				border: none;
-				border-radius: 50%;
-				cursor: pointer;
-				left: 10%;
-				padding: 2em;
-				position: absolute;
-				top: 10%;
-				transform: scale(0.5);
-				z-index: 2;
-			}
-
-
-			#d2l-labs-media-player-video-poster-play-button > d2l-icon {
-				color: #ffffff;
-			}
-
-			#d2l-labs-media-player-media-controls {
-				bottom: 0;
-				position: absolute;
-				transition: bottom 500ms ease;
-				width: 100%;
-				z-index: 2;
-			}
-
-			.d2l-labs-media-player-type-is-audio #d2l-labs-media-player-media-controls {
-				background-color: #ffffff;
-			}
-			.d2l-labs-media-player-type-is-video #d2l-labs-media-player-media-controls {
-				background-color: rgba(0, 0, 0, 0.69);
-			}
-
-			#d2l-labs-media-player-media-controls.d2l-labs-media-player-hidden {
-				bottom: -8rem;
-			}
-
-			#d2l-labs-media-player-seek-bar {
-				--d2l-knob-focus-color: #ffffff;
-				--d2l-knob-focus-size: 4px;
-				--d2l-knob-size: 16px;
-				--d2l-outer-knob-color: var(--d2l-color-celestine-plus-1);
-				--d2l-progress-border-radius: 0;
-				position: absolute;
-				top: -9px;
-				width: 100%;
-				z-index: 1;
-			}
-
-			#d2l-labs-media-player-seek-bar:focus {
-				--d2l-knob-box-shadow: 0 2px 6px 3px rgba(0, 0, 0, 1);
-			}
-
-			#d2l-labs-media-player-buttons {
+		@media screen and (max-width: 767px) {
+			#d2l-labs-media-player-track-container > div {
 				align-items: center;
-				direction: ltr;
-				display: flex;
-				flex-direction: row;
-				justify-content: space-between;
-				margin-left: 6px;
-			}
-
-			[dir="rtl"] #d2l-labs-media-player-buttons {
-				margin-left: 0;
-				margin-right: 6px;
-			}
-
-			.d2l-labs-media-player-flex-filler {
-				flex: auto;
-			}
-
-			d2l-button-icon {
-				--d2l-button-icon-min-height: 1.8rem;
-				--d2l-button-icon-min-width: 1.8rem;
-				margin: 6px 6px 6px 0;
-			}
-
-			#d2l-labs-media-player-time:hover {
-				cursor: auto;
-			}
-
-			#d2l-labs-media-player-volume-container {
-				position: relative;
-			}
-
-			#d2l-labs-media-player-volume-level-container {
-				bottom: calc(1.8rem + 6px);
-				height: 11px;
-				left: 0;
-				position: absolute;
-				width: 1.8rem;
-				z-index: 2;
-			}
-
-			#d2l-labs-media-player-volume-level-container.d2l-labs-media-player-hidden {
-				left: -10000px;
-			}
-
-			#d2l-labs-media-player-volume-level-background {
-				align-items: center;
-				background-color: rgba(0, 0, 0, 0.69);
-				border-radius: 0 0.3rem 0.3rem 0;
-				bottom: 4.55rem;
-				display: flex;
-				height: 1.8rem;
-				justify-content: center;
-				left: -2.7rem;
-				padding: 0 0.625rem;
-				position: relative;
-				width: 6rem;
-			}
-
-			#d2l-labs-media-player-volume-slider-container {
-				height: 100%;
-				width: 100%;
-			}
-
-			#d2l-labs-media-player-volume-slider {
-				--d2l-knob-focus-color: #ffffff;
-				--d2l-knob-focus-size: 0.25rem;
-				--d2l-knob-size: 0.8rem;
-				--d2l-outer-knob-color: var(--d2l-color-celestine-plus-1);
-				position: relative;
-				top: calc(0.5rem + 1px);
-			}
-
-			.d2l-labs-media-player-rotated {
-				transform: rotate(-90deg);
-			}
-
-			#d2l-labs-media-player-audio-bars-container {
-				align-items: center;
-				display: flex;
-				flex-wrap: nowrap;
-				height: 8.5rem;
-				justify-content: center;
-				left: calc(2.1rem + 6px);
-				position: absolute;
-				top: calc(50% - 5.125rem);
-				width: calc(100% - 4.2rem - 12px);
-			}
-
-			d2l-labs-media-player-audio-bars {
-				height: 2rem;
-			}
-
-			#d2l-labs-media-player-track-container {
-				align-items: center;
-				color: #ffffff;
 				display: flex;
 				justify-content: center;
-				overflow: hidden;
-				position: absolute;
-				text-align: center;
-				transition: bottom 500ms ease;
 				width: 100%;
 			}
+		}
 
-			@media screen and (min-width: 768px) {
-				#d2l-labs-media-player-track-container > div {
-					align-items: center;
-					display: flex;
-					justify-content: center;
-					min-width: ${MIN_TRACK_WIDTH_PX}px;
-					width: 50%;
-				}
-			}
+		#d2l-labs-media-player-track-container > div > span {
+			background-color: rgba(0, 0, 0, 0.69);
+			box-shadow: 0.3rem 0 0 rgba(0, 0, 0, 0.69), -0.3rem 0 0 rgba(0, 0, 0, 0.69);
+			color: white;
+			line-height: 1.35rem;
+			white-space: pre-wrap;
+		}
 
-			@media screen and (max-width: 767px) {
-				#d2l-labs-media-player-track-container > div {
-					align-items: center;
-					display: flex;
-					justify-content: center;
-					width: 100%;
-				}
-			}
+		#d2l-labs-media-player-audio-play-button-container {
+			background-color: white;
+			position: absolute;
+		}
 
-			#d2l-labs-media-player-track-container > div > span {
-				background-color: rgba(0, 0, 0, 0.69);
-				box-shadow: 0.3rem 0 0 rgba(0, 0, 0, 0.69), -0.3rem 0 0 rgba(0, 0, 0, 0.69);
-				color: white;
-				line-height: 1.35rem;
-				white-space: pre-wrap;
-			}
+		#d2l-labs-media-player-audio-play-button {
+			background-color: transparent;
+			border: none;
+			border-radius: 12px;
+			margin: 2px;
+			padding: 2px;
+		}
 
-			#d2l-labs-media-player-audio-play-button-container {
-				background-color: white;
-				position: absolute;
-			}
+		#d2l-labs-media-player-audio-play-button:focus {
+			outline: none;
+		}
 
-			#d2l-labs-media-player-audio-play-button {
-				background-color: transparent;
-				border: none;
-				border-radius: 12px;
-				margin: 2px;
-				padding: 2px;
-			}
+		#d2l-labs-media-player-audio-play-button:hover {
+			background: var(--d2l-color-mica);
+			background-clip: content-box;
+			cursor: pointer;
+		}
 
-			#d2l-labs-media-player-audio-play-button:focus {
-				outline: none;
-			}
+		#d2l-labs-media-player-audio-play-button:${unsafeCSS(getFocusPseudoClass())} {
+			border: 2px solid var(--d2l-color-celestine);
+		}
 
-			#d2l-labs-media-player-audio-play-button:hover {
-				background: var(--d2l-color-mica);
-				background-clip: content-box;
-				cursor: pointer;
-			}
+		#d2l-labs-media-player-audio-play-button > d2l-icon {
+			height: 2.75rem;
+			width: 2.75rem;
+		}
 
-			#d2l-labs-media-player-audio-play-button:${unsafeCSS(getFocusPseudoClass())} {
-				border: 2px solid var(--d2l-color-celestine);
-			}
+		.d2l-labs-media-player-chapter-marker, .d2l-labs-media-player-chapter-marker-highlight {
+			cursor: pointer;
+			height: 6px;
+			pointer-events: none;
+			position: absolute;
+			top: 4px;
+			width: 3px;
+			z-index: 2;
+		}
 
-			#d2l-labs-media-player-audio-play-button > d2l-icon {
-				height: 2.75rem;
-				width: 2.75rem;
-			}
+		.d2l-labs-media-player-chapter-marker {
+			background-color: var(--d2l-color-ferrite);
+		}
 
-			.d2l-labs-media-player-chapter-marker, .d2l-labs-media-player-chapter-marker-highlight {
-				cursor: pointer;
-				height: 6px;
-				pointer-events: none;
-				position: absolute;
-				top: 4px;
-				width: 3px;
-				z-index: 2;
-			}
+		.d2l-labs-media-player-chapter-marker-highlight {
+			background-color: var(--d2l-color-celestine-minus-1);
+		}
 
-			.d2l-labs-media-player-chapter-marker {
-				background-color: var(--d2l-color-ferrite);
-			}
+		.d2l-labs-media-player-chapter-marker[theme="dark"] {
+			background-color: white;
+		}
 
-			.d2l-labs-media-player-chapter-marker-highlight {
-				background-color: var(--d2l-color-celestine-minus-1);
-			}
+		#d2l-labs-media-player-search-container {
+			align-items: center;
+			display: flex;
+		}
+		#d2l-labs-media-player-search-container.d2l-labs-media-player-search-container-hidden {
+			display: none;
+		}
 
-			.d2l-labs-media-player-chapter-marker[theme="dark"] {
-				background-color: white;
-			}
+		#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input {
+			border-color: rgba(48, 52, 54, 0.1);
+			border-radius: 20px;
+			color: var(--d2l-color-ferrite);
+			font-size: 1rem;
+			opacity: 0;
+			outline: 0;
+			padding: 0;
+			position: relative;
+			transition: width 0.4s, opacity 0.4s, visibility 0s;
+			visibility: hidden;
+			width: 0;
+		}
 
-			#d2l-labs-media-player-search-container {
-				align-items: center;
-				display: flex;
-			}
-			#d2l-labs-media-player-search-container.d2l-labs-media-player-search-container-hidden {
-				display: none;
-			}
+		#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input[theme="dark"] {
+			background-color: rgba(24, 26, 27, 0.15);
+			color: rgb(206, 216, 225);
+		}
 
-			#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input {
-				border-color: rgba(48, 52, 54, 0.1);
-				border-radius: 20px;
-				color: var(--d2l-color-ferrite);
-				font-size: 1rem;
-				opacity: 0;
-				outline: 0;
-				padding: 0;
-				position: relative;
-				transition: width 0.4s, opacity 0.4s, visibility 0s;
-				visibility: hidden;
-				width: 0;
-			}
+		#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input:focus,
+		#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input:active {
+			box-shadow: rgb(24 26 27) 0 0 1px;
+			outline-color: initial;
+		}
 
-			#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input[theme="dark"] {
-				background-color: rgba(24, 26, 27, 0.15);
-				color: rgb(206, 216, 225);
-			}
+		#d2l-labs-media-player-search-container:hover #d2l-labs-media-player-search-input,
+		#d2l-labs-media-player-search-container.d2l-labs-media-player-search-container-hover #d2l-labs-media-player-search-input {
+			height: 1.2rem;
+			opacity: 1;
+			padding: 0 0.35rem;
+			visibility: visible;
+			width: 6rem;
+		}
 
-			#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input:focus,
-			#d2l-labs-media-player-search-container #d2l-labs-media-player-search-input:active {
-				box-shadow: rgb(24 26 27) 0 0 1px;
-				outline-color: initial;
-			}
+		#d2l-labs-media-player-timeline-markers-container {
+			position: absolute;
+			top: -9px;
+			transition: all 0.2s;
+			width: 100%;
+		}
 
-			#d2l-labs-media-player-search-container:hover #d2l-labs-media-player-search-input,
-			#d2l-labs-media-player-search-container.d2l-labs-media-player-search-container-hover #d2l-labs-media-player-search-input {
-				height: 1.2rem;
-				opacity: 1;
-				padding: 0 0.35rem;
-				visibility: visible;
-				width: 6rem;
-			}
+		#d2l-labs-media-player-thumbnails-preview-container {
+			bottom: 60px;
+			position: absolute;
+			transform: translateX(-50%);
+			z-index: 2;
+		}
 
-			#d2l-labs-media-player-timeline-markers-container {
-				position: absolute;
-				top: -9px;
-				transition: all 0.2s;
-				width: 100%;
-			}
+		#d2l-labs-media-player-thumbnails-preview-chapter {
+			background: #00000072;
+			position: absolute;
+			text-align: center;
+			text-shadow: 0 0 5px rgb(0 0 0 / 75%);
+			width: 100%;
+			z-index: 2;
+		}
 
-			#d2l-labs-media-player-thumbnails-preview-container {
-				bottom: 60px;
-				position: absolute;
-				transform: translateX(-50%);
-				z-index: 2;
-			}
+		#d2l-labs-media-player-thumbnails-preview-time {
+			background: #00000042;
+			bottom: 3px;
+			font-size: 14px;
+			left: 0;
+			position: absolute;
+			text-align: center;
+			text-shadow: 0 0 4px rgb(0 0 0 / 75%);
+			width: 100%;
+			z-index: 2;
+		}
 
-			#d2l-labs-media-player-thumbnails-preview-chapter {
-				background: #00000072;
-				position: absolute;
-				text-align: center;
-				text-shadow: 0 0 5px rgb(0 0 0 / 75%);
-				width: 100%;
-				z-index: 2;
-			}
+		#d2l-labs-media-player-thumbnails-preview-image {
+			background-repeat: no-repeat;
+			position: relative;
+			width: 100%;
+			z-index: 2;
+		}
 
-			#d2l-labs-media-player-thumbnails-preview-time {
-				background: #00000042;
-				bottom: 3px;
-				font-size: 14px;
-				left: 0;
-				position: absolute;
-				text-align: center;
-				text-shadow: 0 0 4px rgb(0 0 0 / 75%);
-				width: 100%;
-				z-index: 2;
-			}
+		.d2l-labs-media-player-search-marker {
+			color: var(--d2l-color-ferrite);
+			cursor: pointer;
+			height: 6px;
+			pointer-events: none;
+			position: absolute;
+			top: 4px;
+			width: 6px;
+			z-index: 2;
+		}
 
-			#d2l-labs-media-player-thumbnails-preview-image {
-				background-repeat: no-repeat;
-				position: relative;
-				width: 100%;
-				z-index: 2;
-			}
+		.d2l-labs-media-player-search-marker[theme="dark"] {
+			color: white;
+		}
 
-			.d2l-labs-media-player-search-marker {
-				color: var(--d2l-color-ferrite);
-				cursor: pointer;
-				height: 6px;
-				pointer-events: none;
-				position: absolute;
-				top: 4px;
-				width: 6px;
-				z-index: 2;
-			}
+		.d2l-labs-media-player-full-area-centered {
+			align-items: center;
+			display: flex;
+			height: 100%;
+			justify-content: center;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 100%;
+			z-index: 2;
+		}
 
-			.d2l-labs-media-player-search-marker[theme="dark"] {
-				color: white;
-			}
+		#d2l-labs-media-player-alert-inner {
+			display: flex;
+			flex-direction: row;
+			justify-content: flex-start;
+		}
 
-			.d2l-labs-media-player-full-area-centered {
-				align-items: center;
-				display: flex;
-				height: 100%;
-				justify-content: center;
-				left: 0;
-				position: absolute;
-				top: 0;
-				width: 100%;
-				z-index: 2;
-			}
+		#d2l-labs-media-player-alert-inner > svg {
+			flex-shrink: 0;
+			margin-right: 0.5rem;
+		}
 
-			#d2l-labs-media-player-alert-inner {
-				display: flex;
-				flex-direction: row;
-				justify-content: flex-start;
-			}
+		#d2l-labs-media-player-alert-inner > span {
+			font-size: 1rem;
+			line-height: 2.1rem;
+		}
 
-			#d2l-labs-media-player-alert-inner > svg {
-				flex-shrink: 0;
-				margin-right: 0.5rem;
-			}
-
-			#d2l-labs-media-player-alert-inner > span {
-				font-size: 1rem;
-				line-height: 2.1rem;
-			}
-
-			.transcript-cue-container {
-				padding-left: 10px;
-			}
-			.video-transcript-cue {
-				padding-left: 5px;
-			}
-			.audio-transcript-cue {
-				padding-left: 5px;
-			}
-			.video-transcript-cue[active] {
-				background-color: gray;
-				box-shadow: -5px 0 0 white;
-			}
-			.audio-transcript-cue[active] {
-				background-color: lightgray;
-				box-shadow: -5px 0 0 black;
-			}
-			#video-transcript-viewer {
-				bottom: 55px;
-				color: white;
-				overflow-anchor: none;
-				overflow-y: auto;
-				position: absolute;
-				right: 0;
-				top: 50px;
-				width: 65%;
-				z-index: 1;
-			}
-			#audio-transcript-viewer {
-				bottom: 60px;
-				color: black;
-				overflow-anchor: none;
-				overflow-y: auto;
-				position: absolute;
-				right: 0;
-				top: 45px;
-				width: 100%;
-				z-index: 1;
-			}
-			#close-transcript {
-				position: absolute;
-				right: 7px;
-				top: 0;
-				z-index: 1;
-			}
-			#video-transcript-download-button {
-				left: 35%;
-				position: absolute;
-				top: 5px;
-				z-index: 2;
-			}
-			#audio-transcript-download-button {
-				left: 10px;
-				position: absolute;
-				top: 0;
-				z-index: 2;
-			}
-			#audio-transcript-download-menu {
-				left: 35px;
-			}
-			#video-close-transcript-icon {
-				color: white;
-			}
-			#audio-close-transcript-icon {
-				color: black;
-			}
-	` ];
-	}
+		.transcript-cue-container {
+			padding-left: 10px;
+		}
+		.video-transcript-cue {
+			padding-left: 5px;
+		}
+		.audio-transcript-cue {
+			padding-left: 5px;
+		}
+		.video-transcript-cue[active] {
+			background-color: gray;
+			box-shadow: -5px 0 0 white;
+		}
+		.audio-transcript-cue[active] {
+			background-color: lightgray;
+			box-shadow: -5px 0 0 black;
+		}
+		#video-transcript-viewer {
+			bottom: 55px;
+			color: white;
+			overflow-anchor: none;
+			overflow-y: auto;
+			position: absolute;
+			right: 0;
+			top: 50px;
+			width: 65%;
+			z-index: 1;
+		}
+		#audio-transcript-viewer {
+			bottom: 60px;
+			color: black;
+			overflow-anchor: none;
+			overflow-y: auto;
+			position: absolute;
+			right: 0;
+			top: 45px;
+			width: 100%;
+			z-index: 1;
+		}
+		#close-transcript {
+			position: absolute;
+			right: 7px;
+			top: 0;
+			z-index: 1;
+		}
+		#video-transcript-download-button {
+			left: 35%;
+			position: absolute;
+			top: 5px;
+			z-index: 2;
+		}
+		#audio-transcript-download-button {
+			left: 10px;
+			position: absolute;
+			top: 0;
+			z-index: 2;
+		}
+		#audio-transcript-download-menu {
+			left: 35px;
+		}
+		#video-close-transcript-icon {
+			color: white;
+		}
+		#audio-close-transcript-icon {
+			color: black;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/media-player/slider-bar.js
+++ b/src/components/media-player/slider-bar.js
@@ -6,141 +6,138 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 class SliderBar extends PropertyRequiredMixin(LocalizeLabsElement(RtlMixin(LitElement))) {
 
-	static get properties() {
-		return {
-			value: { type: Number },
-			immediateValue: { type: Number, reflect: true },
-			hoverValue: { type: Number, reflect: true },
-			dragging: { type: Boolean, reflect: true },
-			hovering: { type: Boolean, reflect: true },
-			vertical: { type: Boolean },
-			fullWidth: { type: Boolean },
-			min: { type: Number },
-			max: { type: Number },
-			label: { type: String, required: true },
-		};
-	}
+	static properties = {
+		value: { type: Number },
+		immediateValue: { type: Number, reflect: true },
+		hoverValue: { type: Number, reflect: true },
+		dragging: { type: Boolean, reflect: true },
+		hovering: { type: Boolean, reflect: true },
+		vertical: { type: Boolean },
+		fullWidth: { type: Boolean },
+		min: { type: Number },
+		max: { type: Number },
+		label: { type: String, required: true },
+	};
 
-	static get styles() {
-		return css`
-	:host {
-		--d2l-color-corundum-65-opacity: rgba(177, 185, 190, 0.65);
-		--d2l-color-galena-88-opacity: rgba(110, 116, 119, 0.88);
-		--d2l-calculated-seek-bar-height: var(--d2l-seek-bar-height, 6px);
-		--d2l-calculated-knob-size: var(--d2l-knob-size, 32px);
-		--d2l-half-knob-size: calc(var(--d2l-calculated-knob-size)/2);
-		--d2l-half-knob-size-overflow: calc((var(--d2l-calculated-knob-size) - var(--d2l-calculated-seek-bar-height)) / 2 - 1px);
-		--d2l-calculated-inner-knob-margin: var(--d2l-inner-knob-margin, 8px);
-		--d2l-calculated-knob-box-shadow: var(--d2l-knob-box-shadow, 0 2px 4px 0 rgba(0, 0, 0, 0.52));
-		--d2l-calculated-outer-knob-color: var(--d2l-outer-knob-color, var(--d2l-color-regolith));
-		--d2l-calculated-outer-knob-border-color: var(--d2l-outer-knob-border-color, var(--d2l-color-pressicus));
-		--d2l-inner-knob-color: var(--d2l-inner-knob-color, var(--d2l-color-celestine-plus-1));
-		--d2l-calculated-knob-focus-color: var(--d2l-knob-focus-color, var(--d2l-color-celestine));
-		--d2l-calculated-knob-focus-size: var(--d2l-knob-focus-size, 2px);
-		--d2l-calculated-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
-		--d2l-calculated-progress-border-radius: var(--d2l-progress-border-radius, 6px);
-		--d2l-calculated-progress-shadow-color: var(--d2l-progress-shadow-color, var(--d2l-color-galena-88-opacity));
-		--d2l-calculated-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-celestine-plus-1));
-		--d2l-calculated-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-corundum-65-opacity));
-		display: block;
-	}
+	static styles = css`
+		:host {
+			--d2l-color-corundum-65-opacity: rgba(177, 185, 190, 0.65);
+			--d2l-color-galena-88-opacity: rgba(110, 116, 119, 0.88);
+			--d2l-calculated-seek-bar-height: var(--d2l-seek-bar-height, 6px);
+			--d2l-calculated-knob-size: var(--d2l-knob-size, 32px);
+			--d2l-half-knob-size: calc(var(--d2l-calculated-knob-size)/2);
+			--d2l-half-knob-size-overflow: calc((var(--d2l-calculated-knob-size) - var(--d2l-calculated-seek-bar-height)) / 2 - 1px);
+			--d2l-calculated-inner-knob-margin: var(--d2l-inner-knob-margin, 8px);
+			--d2l-calculated-knob-box-shadow: var(--d2l-knob-box-shadow, 0 2px 4px 0 rgba(0, 0, 0, 0.52));
+			--d2l-calculated-outer-knob-color: var(--d2l-outer-knob-color, var(--d2l-color-regolith));
+			--d2l-calculated-outer-knob-border-color: var(--d2l-outer-knob-border-color, var(--d2l-color-pressicus));
+			--d2l-inner-knob-color: var(--d2l-inner-knob-color, var(--d2l-color-celestine-plus-1));
+			--d2l-calculated-knob-focus-color: var(--d2l-knob-focus-color, var(--d2l-color-celestine));
+			--d2l-calculated-knob-focus-size: var(--d2l-knob-focus-size, 2px);
+			--d2l-calculated-progress-border-color: var(--d2l-progress-border-color, var(--d2l-color-pressicus));
+			--d2l-calculated-progress-border-radius: var(--d2l-progress-border-radius, 6px);
+			--d2l-calculated-progress-shadow-color: var(--d2l-progress-shadow-color, var(--d2l-color-galena-88-opacity));
+			--d2l-calculated-progress-active-color: var(--d2l-progress-active-color, var(--d2l-color-celestine-plus-1));
+			--d2l-calculated-progress-background-color: var(--d2l-progress-background-color, var(--d2l-color-corundum-65-opacity));
+			display: block;
+		}
 
-	:host(:focus-within) {
-		outline: none;
-	}
+		:host(:focus-within) {
+			outline: none;
+		}
 
-	:host(:focus-within) .slider-knob::after {
-		border-radius: 50%;
-		bottom: 0;
-		box-shadow: 0 0 0 var(--d2l-calculated-knob-focus-size) var(--d2l-calculated-knob-focus-color);
-		content: "";
-		left: 0;
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
+		:host(:focus-within) .slider-knob::after {
+			border-radius: 50%;
+			bottom: 0;
+			box-shadow: 0 0 0 var(--d2l-calculated-knob-focus-size) var(--d2l-calculated-knob-focus-color);
+			content: "";
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
 
-	:host([solid]) .slider-knob-inner {
-		display: none;
-	}
+		:host([solid]) .slider-knob-inner {
+			display: none;
+		}
 
-	#sliderContainer {
-		height: var(--d2l-calculated-knob-size);
-		margin-left: var(--d2l-half-knob-size);
-		margin-right: var(--d2l-half-knob-size);
-		position: relative;
-	}
+		#sliderContainer {
+			height: var(--d2l-calculated-knob-size);
+			margin-left: var(--d2l-half-knob-size);
+			margin-right: var(--d2l-half-knob-size);
+			position: relative;
+		}
 
-	#knobContainer {
-		bottom: 0;
-		left: 0;
-		pointer-events: none;
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
+		#knobContainer {
+			bottom: 0;
+			left: 0;
+			pointer-events: none;
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
 
-	:host([fullWidth]) #sliderContainer {
-		margin-left: 0;
-		margin-right: 0;
-	}
+		:host([fullWidth]) #sliderContainer {
+			margin-left: 0;
+			margin-right: 0;
+		}
 
-	:host([fullWidth]) #knobContainer {
-		left: var(--d2l-half-knob-size);
-		right: var(--d2l-half-knob-size);
-	}
+		:host([fullWidth]) #knobContainer {
+			left: var(--d2l-half-knob-size);
+			right: var(--d2l-half-knob-size);
+		}
 
-	.bar-container {
-		cursor: pointer;
-		overflow: hidden;
-	}
+		.bar-container {
+			cursor: pointer;
+			overflow: hidden;
+		}
 
-	#sliderBar {
-		padding: var(--d2l-half-knob-size-overflow) 0;
-		width: 100%;
-	}
+		#sliderBar {
+			padding: var(--d2l-half-knob-size-overflow) 0;
+			width: 100%;
+		}
 
-	#progressContainer {
-		--d2l-progress-container-color: var(--d2l-calculated-progress-background-color);
-		background: var(--d2l-progress-container-color, var(--d2l-color-gypsum));
-		border-radius: var(--d2l-calculated-progress-border-radius);
-		box-shadow: inset 0 1px 0 0 var(--d2l-calculated-progress-shadow-color);
-		height: var(--d2l-progress-height, 6px);
-		position: relative;
-	}
+		#progressContainer {
+			--d2l-progress-container-color: var(--d2l-calculated-progress-background-color);
+			background: var(--d2l-progress-container-color, var(--d2l-color-gypsum));
+			border-radius: var(--d2l-calculated-progress-border-radius);
+			box-shadow: inset 0 1px 0 0 var(--d2l-calculated-progress-shadow-color);
+			height: var(--d2l-progress-height, 6px);
+			position: relative;
+		}
 
-	#primaryProgress {
-		--d2l-progress-active-color: var(--d2l-calculated-progress-active-color);
-		background: var(--d2l-progress-active-color, var(--d2l-color-celestine));
-		border-radius: var(--d2l-calculated-progress-border-radius);
-		box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.07);
-		height: 100%;
-	}
+		#primaryProgress {
+			--d2l-progress-active-color: var(--d2l-calculated-progress-active-color);
+			background: var(--d2l-progress-active-color, var(--d2l-color-celestine));
+			border-radius: var(--d2l-calculated-progress-border-radius);
+			box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.07);
+			height: 100%;
+		}
 
-	.slider-knob {
-		background-color: var(--d2l-calculated-outer-knob-color);
-		border-radius: 50%;
-		box-shadow: var(--d2l-calculated-knob-box-shadow);
-		cursor: pointer;
-		height: calc((((var(--d2l-calculated-knob-size) / 2) - var(--d2l-calculated-seek-bar-height) / 2) * 2) + var(--d2l-calculated-seek-bar-height) - 2px);
-		left: 0;
-		margin-left: calc(-1 * ((var(--d2l-calculated-knob-size) / 2) - var(--d2l-calculated-seek-bar-height) / 2) - var(--d2l-calculated-seek-bar-height) / 2);
-		position: absolute;
-		top: 0;
-		width: calc((((var(--d2l-calculated-knob-size) / 2) - var(--d2l-calculated-seek-bar-height) / 2) * 2) + var(--d2l-calculated-seek-bar-height) - 2px);
-		z-index: 1;
-	}
+		.slider-knob {
+			background-color: var(--d2l-calculated-outer-knob-color);
+			border-radius: 50%;
+			box-shadow: var(--d2l-calculated-knob-box-shadow);
+			cursor: pointer;
+			height: calc((((var(--d2l-calculated-knob-size) / 2) - var(--d2l-calculated-seek-bar-height) / 2) * 2) + var(--d2l-calculated-seek-bar-height) - 2px);
+			left: 0;
+			margin-left: calc(-1 * ((var(--d2l-calculated-knob-size) / 2) - var(--d2l-calculated-seek-bar-height) / 2) - var(--d2l-calculated-seek-bar-height) / 2);
+			position: absolute;
+			top: 0;
+			width: calc((((var(--d2l-calculated-knob-size) / 2) - var(--d2l-calculated-seek-bar-height) / 2) * 2) + var(--d2l-calculated-seek-bar-height) - 2px);
+			z-index: 1;
+		}
 
-	.slider-knob-inner {
-		background-color: var(--d2l-inner-knob-color);
-		border-radius: 50%;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.07);
-		box-sizing: border-box;
-		height: calc(100% - var(--d2l-calculated-inner-knob-margin) *2);
-		margin: var(--d2l-calculated-inner-knob-margin);
-		width: calc(100% - var(--d2l-calculated-inner-knob-margin) *2);
-	}`;
-	}
+		.slider-knob-inner {
+			background-color: var(--d2l-inner-knob-color);
+			border-radius: 50%;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.07);
+			box-sizing: border-box;
+			height: calc(100% - var(--d2l-calculated-inner-knob-margin) *2);
+			margin: var(--d2l-calculated-inner-knob-margin);
+			width: calc(100% - var(--d2l-calculated-inner-knob-margin) *2);
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-band.js
+++ b/src/components/navigation/navigation-band.js
@@ -9,84 +9,82 @@ function useCustomScroll() {
 
 class NavigationBand extends LitElement {
 
-	static get styles() {
-		return [centererStyles, guttersStyles, css`
-			:host {
-				background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) 1.5rem, #ffffff 0%);
-				display: block;
-				min-height: 4px;
-				position: relative; /* Needed for Firefox */
-			}
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = [centererStyles, guttersStyles, css`
+		:host {
+			background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) 1.5rem, #ffffff 0%);
+			display: block;
+			min-height: 4px;
+			position: relative; /* Needed for Firefox */
+		}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-labs-navigation-scroll {
-				overflow-x: auto;
-				overflow-y: hidden;
-				scroll-behavior: smooth;
-			}
+		.d2l-labs-navigation-scroll {
+			overflow-x: auto;
+			overflow-y: hidden;
+			scroll-behavior: smooth;
+		}
 
-			.d2l-labs-navigation-scroll[data-custom-scroll] {
-				/* Firefox Styles */
-				scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
-				scrollbar-width: thin;
-			}
-			/* Webkit Styles */
-			.d2l-labs-navigation-scroll[data-custom-scroll]::-webkit-scrollbar {
-				background-color: var(--d2l-color-sylvite);
-				border-radius: 8px;
-				height: 9px;
-			}
-			.d2l-labs-navigation-scroll[data-custom-scroll]::-webkit-scrollbar-thumb {
-				background-color: var(--d2l-color-galena);
-				border-bottom: 1px solid var(--d2l-color-sylvite);
-				border-radius: 8px;
-				border-top: 1px solid var(--d2l-color-sylvite);
-			}
-			/* Faded edges styles */
+		.d2l-labs-navigation-scroll[data-custom-scroll] {
+			/* Firefox Styles */
+			scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
+			scrollbar-width: thin;
+		}
+		/* Webkit Styles */
+		.d2l-labs-navigation-scroll[data-custom-scroll]::-webkit-scrollbar {
+			background-color: var(--d2l-color-sylvite);
+			border-radius: 8px;
+			height: 9px;
+		}
+		.d2l-labs-navigation-scroll[data-custom-scroll]::-webkit-scrollbar-thumb {
+			background-color: var(--d2l-color-galena);
+			border-bottom: 1px solid var(--d2l-color-sylvite);
+			border-radius: 8px;
+			border-top: 1px solid var(--d2l-color-sylvite);
+		}
+		/* Faded edges styles */
+		.d2l-labs-navigation-scroll-before,
+		.d2l-labs-navigation-scroll-after {
+			height: 100%;
+			max-height: 1.5rem; /* should match linear-background height */
+			pointer-events: none;
+			position: absolute;
+			top: 0;
+			width: 2.439%; /* should match gutter width */
+			z-index: 2;
+		}
+		.d2l-labs-navigation-scroll-before {
+			background: linear-gradient(to right, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
+			left: 0;
+		}
+		.d2l-labs-navigation-scroll-after {
+			background: linear-gradient(to left, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
+			right: 0;
+		}
+		/* Styles to ensure the right padding is respected when scrolling */
+		.d2l-labs-navigation-centerer {
+			line-height: 0;
+			position: relative;
+		}
+		.d2l-labs-navigation-gutters {
+			display: inline-block;
+			position: unset;
+			vertical-align: top;
+		}
+		@media (max-width: 615px) {
 			.d2l-labs-navigation-scroll-before,
 			.d2l-labs-navigation-scroll-after {
-				height: 100%;
-				max-height: 1.5rem; /* should match linear-background height */
-				pointer-events: none;
-				position: absolute;
-				top: 0;
-				width: 2.439%; /* should match gutter width */
-				z-index: 2;
+				width: 15px;
 			}
-			.d2l-labs-navigation-scroll-before {
-				background: linear-gradient(to right, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
-				left: 0;
-			}
+		}
+		@media (min-width: 1230px) {
+			.d2l-labs-navigation-scroll-before,
 			.d2l-labs-navigation-scroll-after {
-				background: linear-gradient(to left, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
-				right: 0;
+				width: 30px;
 			}
-			/* Styles to ensure the right padding is respected when scrolling */
-			.d2l-labs-navigation-centerer {
-				line-height: 0;
-				position: relative;
-			}
-			.d2l-labs-navigation-gutters {
-				display: inline-block;
-				position: unset;
-				vertical-align: top;
-			}
-			@media (max-width: 615px) {
-				.d2l-labs-navigation-scroll-before,
-				.d2l-labs-navigation-scroll-after {
-					width: 15px;
-				}
-			}
-			@media (min-width: 1230px) {
-				.d2l-labs-navigation-scroll-before,
-				.d2l-labs-navigation-scroll-after {
-					width: 30px;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-button-icon.js
+++ b/src/components/navigation/navigation-button-icon.js
@@ -12,62 +12,58 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  */
 class NavigationButtonIcon extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Disables the button
-			 * @type {boolean}
-			 */
-			disabled: { reflect: true, type: Boolean },
-			/**
-			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
-			 * @type {string}
-			 */
-			icon: { type: String },
-			/**
-			 * Position of the icon.
-			 * @type {'start'|'end'}
-			 */
-			iconPosition: { attribute: 'icon-position', type: String },
-			/**
-			 * Visually hides the highlight border when hovered/focused
-			 * @type {boolean}
-			 */
-			noHighlightBorder: { attribute: 'no-highlight-border', type: Boolean },
-			/**
-			 * REQUIRED: Text for the button
-			 * @type {string}
-			 */
-			text: { type: String },
-			/**
-			 * Visually hides the text but still accessible
-			 * @type {boolean}
-			 */
-			textHidden: { attribute: 'text-hidden', type: Boolean },
-			/**
-			 * Offset of the tooltip
-			 * @type {Number}
-			 */
-			tooltipOffset: { attribute: 'tooltip-offset', type: Number },
-			/**
-			 * Position of the tooltip
-			 * @type {'top'|'bottom'|'left'|'right'}
-			 */
-			tooltipPosition: { attribute: 'tooltip-position', type: String }
-		};
-	}
+	static properties = {
+		/**
+		 * Disables the button
+		 * @type {boolean}
+		 */
+		disabled: { reflect: true, type: Boolean },
+		/**
+		 * REQUIRED: Preset icon key (e.g. "tier1:gear")
+		 * @type {string}
+		 */
+		icon: { type: String },
+		/**
+		 * Position of the icon.
+		 * @type {'start'|'end'}
+		 */
+		iconPosition: { attribute: 'icon-position', type: String },
+		/**
+		 * Visually hides the highlight border when hovered/focused
+		 * @type {boolean}
+		 */
+		noHighlightBorder: { attribute: 'no-highlight-border', type: Boolean },
+		/**
+		 * REQUIRED: Text for the button
+		 * @type {string}
+		 */
+		text: { type: String },
+		/**
+		 * Visually hides the text but still accessible
+		 * @type {boolean}
+		 */
+		textHidden: { attribute: 'text-hidden', type: Boolean },
+		/**
+		 * Offset of the tooltip
+		 * @type {Number}
+		 */
+		tooltipOffset: { attribute: 'tooltip-offset', type: Number },
+		/**
+		 * Position of the tooltip
+		 * @type {'top'|'bottom'|'left'|'right'}
+		 */
+		tooltipPosition: { attribute: 'tooltip-position', type: String }
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, highlightButtonStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, highlightButtonStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-dropdown-button-custom.js
+++ b/src/components/navigation/navigation-dropdown-button-custom.js
@@ -5,24 +5,20 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class NavigationDropdownButtonCustom extends DropdownOpenerMixin(LitElement) {
 
-	static get properties() {
-		return {
-			openerLabel: { type: String, attribute: 'opener-label' }
-		};
-	}
+	static properties = {
+		openerLabel: { type: String, attribute: 'opener-label' }
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, highlightButtonStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-				position: relative;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, highlightButtonStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+			position: relative;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	render() {
 		return html`

--- a/src/components/navigation/navigation-dropdown-button-icon.js
+++ b/src/components/navigation/navigation-dropdown-button-icon.js
@@ -10,32 +10,28 @@ import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offsc
 
 class NavigationDropdownButtonIcon extends DropdownOpenerMixin(LitElement) {
 
-	static get properties() {
-		return {
-			icon: { type: String },
-			hasNotification: { attribute: 'has-notification', reflect: true, type: Boolean },
-			text: { type: String },
-			notificationText: { attribute: 'notification-text', type: String },
-			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
-		};
-	}
+	static properties = {
+		icon: { type: String },
+		hasNotification: { attribute: 'has-notification', reflect: true, type: Boolean },
+		text: { type: String },
+		notificationText: { attribute: 'notification-text', type: String },
+		tooltipOffset: { attribute: 'tooltip-offset', type: Number }
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, highlightButtonStyles, offscreenStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-				position: relative;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.icon-container {
-				display: inline-block;
-				position: relative;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, highlightButtonStyles, offscreenStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+			position: relative;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		.icon-container {
+			display: inline-block;
+			position: relative;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-immersive.js
+++ b/src/components/navigation/navigation-immersive.js
@@ -11,157 +11,153 @@ const mediaQueryList = window.matchMedia('(max-width: 615px)');
 
 class NavigationImmersive extends LitElement {
 
-	static get properties() {
-		return {
-			allowOverflow: {
-				attribute: 'allow-overflow',
-				type: Boolean,
-				reflect: true
-			},
-			backLinkHref: {
-				attribute: 'back-link-href',
-				type: String
-			},
-			backLinkText: {
-				attribute: 'back-link-text',
-				type: String
-			},
-			backLinkTextShort: {
-				attribute: 'back-link-text-short',
-				type: String
-			},
-			widthType: {
-				attribute: 'width-type',
-				type: String,
-				reflect: true
-			},
-			_dynamicSpacingHeight: { state: true },
-			_middleHidden: { state: true },
-			_middleNoRightBorder: { state: true },
-			_smallWidth: { state: true }
-		};
-	}
+	static properties = {
+		allowOverflow: {
+			attribute: 'allow-overflow',
+			type: Boolean,
+			reflect: true
+		},
+		backLinkHref: {
+			attribute: 'back-link-href',
+			type: String
+		},
+		backLinkText: {
+			attribute: 'back-link-text',
+			type: String
+		},
+		backLinkTextShort: {
+			attribute: 'back-link-text-short',
+			type: String
+		},
+		widthType: {
+			attribute: 'width-type',
+			type: String,
+			reflect: true
+		},
+		_dynamicSpacingHeight: { state: true },
+		_middleHidden: { state: true },
+		_middleNoRightBorder: { state: true },
+		_smallWidth: { state: true }
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, navigationSharedStyle, css`
-			:host {
-				--d2l-labs-navigation-immersive-height-main: 3.1rem;
-				--d2l-labs-navigation-immersive-height-responsive: 2.8rem;
-			}
-			.d2l-navigiation-immersive-fixed {
-				background-color: white;
-				left: 0;
-				position: fixed;
-				right: 0;
-				top: 0;
-				z-index: 2; /* higher than skeletons which could scroll behind immersive nav */
-			}
-			d2l-labs-navigation {
-				border-bottom: 1px solid var(--d2l-color-mica);
-			}
+	static styles = [bodyCompactStyles, navigationSharedStyle, css`
+		:host {
+			--d2l-labs-navigation-immersive-height-main: 3.1rem;
+			--d2l-labs-navigation-immersive-height-responsive: 2.8rem;
+		}
+		.d2l-navigiation-immersive-fixed {
+			background-color: white;
+			left: 0;
+			position: fixed;
+			right: 0;
+			top: 0;
+			z-index: 2; /* higher than skeletons which could scroll behind immersive nav */
+		}
+		d2l-labs-navigation {
+			border-bottom: 1px solid var(--d2l-color-mica);
+		}
+		.d2l-labs-navigation-immersive-margin {
+			display: flex;
+			justify-content: center;
+			margin: 0 30px;
+		}
+
+		.d2l-labs-navigation-immersive-container {
+			display: flex;
+			height: var(--d2l-labs-navigation-immersive-height-main);
+			justify-content: space-between;
+			margin: 0 -7px;
+			max-width: 100%;
+			overflow: hidden;
+			width: 100%;
+		}
+
+		:host([width-type="normal"]) .d2l-labs-navigation-immersive-container {
+			max-width: 1230px;
+		}
+
+		:host([allow-overflow]) .d2l-labs-navigation-immersive-container {
+			overflow: visible;
+		}
+
+		.d2l-labs-navigation-immersive-left ::slotted(*),
+		.d2l-labs-navigation-immersive-middle ::slotted(*),
+		.d2l-labs-navigation-immersive-right ::slotted(*) {
+			height: var(--d2l-labs-navigation-immersive-height-main);
+		}
+
+		.d2l-labs-navigation-immersive-left {
+			color: var(--d2l-color-tungsten);
+			letter-spacing: 0.2px;
+			padding-left: 7px;
+		}
+
+		.d2l-labs-navigation-immersive-right {
+			padding-right: 7px;
+		}
+
+		.d2l-labs-navigation-immersive-left,
+		.d2l-labs-navigation-immersive-right {
+			flex: 0 0 auto;
+		}
+
+		.d2l-labs-navigation-immersive-middle {
+			border-inline-end: 1px solid var(--d2l-color-gypsum);
+			border-inline-start: 1px solid var(--d2l-color-gypsum);
+			flex: 0 1 auto;
+			margin: 0 24px;
+			min-width: 0;
+			padding: 0 24px;
+			width: 100%;
+		}
+
+		.d2l-labs-navigation-immersive-middle.d2l-labs-navigation-immersive-middle-no-right-border {
+			border-inline-end: none;
+		}
+
+		div.d2l-labs-navigation-immersive-middle-observer,
+		div.d2l-labs-navigation-immersive-right-observer {
+			height: auto;
+		}
+
+		.d2l-labs-navigation-immersive-middle-hidden {
+			visibility: hidden;
+		}
+
+		.d2l-labs-navigation-immersive-spacing {
+			position: unset;
+		}
+
+		@media (max-width: 929px) {
 			.d2l-labs-navigation-immersive-margin {
-				display: flex;
-				justify-content: center;
-				margin: 0 30px;
+				margin: 0 24px;
 			}
+		}
 
+		@media (max-width: 767px) {
+			.d2l-labs-navigation-immersive-margin {
+				margin: 0 18px;
+			}
+		}
+
+		@media (max-width: 615px) {
 			.d2l-labs-navigation-immersive-container {
-				display: flex;
-				height: var(--d2l-labs-navigation-immersive-height-main);
-				justify-content: space-between;
-				margin: 0 -7px;
-				max-width: 100%;
-				overflow: hidden;
-				width: 100%;
+				height: var(--d2l-labs-navigation-immersive-height-responsive);
 			}
-
-			:host([width-type="normal"]) .d2l-labs-navigation-immersive-container {
-				max-width: 1230px;
-			}
-
-			:host([allow-overflow]) .d2l-labs-navigation-immersive-container {
-				overflow: visible;
-			}
-
 			.d2l-labs-navigation-immersive-left ::slotted(*),
 			.d2l-labs-navigation-immersive-middle ::slotted(*),
 			.d2l-labs-navigation-immersive-right ::slotted(*) {
-				height: var(--d2l-labs-navigation-immersive-height-main);
+				height: var(--d2l-labs-navigation-immersive-height-responsive);
 			}
-
-			.d2l-labs-navigation-immersive-left {
-				color: var(--d2l-color-tungsten);
-				letter-spacing: 0.2px;
-				padding-left: 7px;
-			}
-
-			.d2l-labs-navigation-immersive-right {
-				padding-right: 7px;
-			}
-
-			.d2l-labs-navigation-immersive-left,
-			.d2l-labs-navigation-immersive-right {
-				flex: 0 0 auto;
-			}
-
-			.d2l-labs-navigation-immersive-middle {
-				border-inline-end: 1px solid var(--d2l-color-gypsum);
-				border-inline-start: 1px solid var(--d2l-color-gypsum);
-				flex: 0 1 auto;
-				margin: 0 24px;
-				min-width: 0;
-				padding: 0 24px;
-				width: 100%;
-			}
-
-			.d2l-labs-navigation-immersive-middle.d2l-labs-navigation-immersive-middle-no-right-border {
-				border-inline-end: none;
-			}
-
-			div.d2l-labs-navigation-immersive-middle-observer,
-			div.d2l-labs-navigation-immersive-right-observer {
-				height: auto;
-			}
-
-			.d2l-labs-navigation-immersive-middle-hidden {
-				visibility: hidden;
-			}
-
 			.d2l-labs-navigation-immersive-spacing {
-				position: unset;
+				height: calc(var(--d2l-labs-navigation-immersive-height-responsive) + 5px);
 			}
-
-			@media (max-width: 929px) {
-				.d2l-labs-navigation-immersive-margin {
-					margin: 0 24px;
-				}
+			.d2l-labs-navigation-immersive-middle {
+				margin: 0 18px;
+				padding: 0 18px;
 			}
-
-			@media (max-width: 767px) {
-				.d2l-labs-navigation-immersive-margin {
-					margin: 0 18px;
-				}
-			}
-
-			@media (max-width: 615px) {
-				.d2l-labs-navigation-immersive-container {
-					height: var(--d2l-labs-navigation-immersive-height-responsive);
-				}
-				.d2l-labs-navigation-immersive-left ::slotted(*),
-				.d2l-labs-navigation-immersive-middle ::slotted(*),
-				.d2l-labs-navigation-immersive-right ::slotted(*) {
-					height: var(--d2l-labs-navigation-immersive-height-responsive);
-				}
-				.d2l-labs-navigation-immersive-spacing {
-					height: calc(var(--d2l-labs-navigation-immersive-height-responsive) + 5px);
-				}
-				.d2l-labs-navigation-immersive-middle {
-					margin: 0 18px;
-					padding: 0 18px;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-iterator.js
+++ b/src/components/navigation/navigation-iterator.js
@@ -5,32 +5,28 @@ import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 class NavigationIterator extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			hideText: { attribute: 'hide-text', type: Boolean },
-			previousDisabled: { attribute: 'previous-disabled', type: Boolean },
-			previousText: { attribute: 'previous-text', type: String },
-			nextDisabled: { attribute: 'next-disabled', type: Boolean },
-			nextText: { attribute: 'next-text', type: String },
-			noHighlightBorder: { attribute: 'no-highlight-border', type: Boolean },
-		};
-	}
+	static properties = {
+		hideText: { attribute: 'hide-text', type: Boolean },
+		previousDisabled: { attribute: 'previous-disabled', type: Boolean },
+		previousText: { attribute: 'previous-text', type: String },
+		nextDisabled: { attribute: 'next-disabled', type: Boolean },
+		nextText: { attribute: 'next-text', type: String },
+		noHighlightBorder: { attribute: 'no-highlight-border', type: Boolean },
+	};
 
-	static get styles() {
-		return [bodyCompactStyles, css`
-			:host {
-				align-items: center;
-				display: flex;
-				gap: 1.2rem;
-				height: 3.3rem;
-				justify-content: space-between;
-				max-width: 20rem;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [bodyCompactStyles, css`
+		:host {
+			align-items: center;
+			display: flex;
+			gap: 1.2rem;
+			height: 3.3rem;
+			justify-content: space-between;
+			max-width: 20rem;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-link-back.js
+++ b/src/components/navigation/navigation-link-back.js
@@ -5,24 +5,20 @@ import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 class NavigationLinkBack extends LocalizeLabsElement(FocusMixin(LitElement)) {
 
-	static get properties() {
-		return {
-			text: { type: String },
-			href: { type: String }
-		};
-	}
+	static properties = {
+		text: { type: String },
+		href: { type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-				height: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+			height: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	static get focusElementSelector() {
 		return 'd2l-labs-navigation-link-icon';

--- a/src/components/navigation/navigation-link-icon.js
+++ b/src/components/navigation/navigation-link-icon.js
@@ -12,47 +12,43 @@ import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offsc
  */
 class NavigationLinkIcon extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * REQUIRED: URL or URL fragment of the link
-			 * @type {string}
-			 */
-			href: { type: String },
-			/**
-			 * REQUIRED: Preset icon key (e.g. "tier1:gear")
-			 * @type {string}
-			 */
-			icon: { type: String },
-			/**
-			 * REQUIRED: Text for the link
-			 * @type {string}
-			 */
-			text: { type: String },
-			/**
-			 * Visually hides the text but still accessible
-			 * @type {boolean}
-			 */
-			textHidden: { attribute: 'text-hidden', type: Boolean },
-			/**
-			 * Offset of the tooltip
-			 * @type {Number}
-			 */
-			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
-		};
-	}
+	static properties = {
+		/**
+		 * REQUIRED: URL or URL fragment of the link
+		 * @type {string}
+		 */
+		href: { type: String },
+		/**
+		 * REQUIRED: Preset icon key (e.g. "tier1:gear")
+		 * @type {string}
+		 */
+		icon: { type: String },
+		/**
+		 * REQUIRED: Text for the link
+		 * @type {string}
+		 */
+		text: { type: String },
+		/**
+		 * Visually hides the text but still accessible
+		 * @type {boolean}
+		 */
+		textHidden: { attribute: 'text-hidden', type: Boolean },
+		/**
+		 * Offset of the tooltip
+		 * @type {Number}
+		 */
+		tooltipOffset: { attribute: 'tooltip-offset', type: Number }
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, highlightLinkStyles, offscreenStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, highlightLinkStyles, offscreenStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-link-image.js
+++ b/src/components/navigation/navigation-link-image.js
@@ -7,42 +7,38 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 class NavigationLinkImage extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			href: { type: String },
-			slim: { reflect: true, type: Boolean },
-			src: { type: String },
-			text: { type: String },
-			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
-		};
-	}
+	static properties = {
+		href: { type: String },
+		slim: { reflect: true, type: Boolean },
+		src: { type: String },
+		text: { type: String },
+		tooltipOffset: { attribute: 'tooltip-offset', type: Number }
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, highlightLinkStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			img {
-				max-height: 60px;
-				max-width: 260px;
-				vertical-align: middle;
-			}
-			:host([slim]) img {
-				max-height: 40px;
-				max-width: 173px;
-			}
-			.d2l-labs-navigation-link-image-container {
-				align-items: center;
-				display: inline-flex;
-				height: 100%;
-				vertical-align: middle;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, highlightLinkStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		img {
+			max-height: 60px;
+			max-width: 260px;
+			vertical-align: middle;
+		}
+		:host([slim]) img {
+			max-height: 40px;
+			max-width: 173px;
+		}
+		.d2l-labs-navigation-link-image-container {
+			align-items: center;
+			display: inline-flex;
+			height: 100%;
+			vertical-align: middle;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation-link.js
+++ b/src/components/navigation/navigation-link.js
@@ -5,45 +5,41 @@ import { highlightBorderStyles } from './navigation-styles.js';
 
 class D2LNavigationLink extends FocusMixin(LitElement) {
 
-	static get properties() {
-		return {
-			href: {
-				reflect: true,
-				type: String
-			},
-			text: {
-				type: String
-			}
-		};
-	}
+	static properties = {
+		href: {
+			reflect: true,
+			type: String
+		},
+		text: {
+			type: String
+		}
+	};
 
-	static get styles() {
-		return [highlightBorderStyles, css`
-			:host {
-				display: inline-block;
-				height: 100%;
-			}
-			a {
-				align-items: center;
-				color: var(--d2l-color-ferrite);
-				display: inline-flex;
-				height: 100%;
-				min-height: 40px;
-				position: relative;
-				text-decoration: none;
-				vertical-align: middle;
-			}
-			a:hover,
-			a:focus {
-				--d2l-icon-fill-color: var(--d2l-color-celestine);
-				color: var(--d2l-color-celestine);
-				outline: none;
-			}
-			:host(:not([href])) .d2l-labs-navigation-highlight-border {
-				display: none;
-			}
-		`];
-	}
+	static styles = [highlightBorderStyles, css`
+		:host {
+			display: inline-block;
+			height: 100%;
+		}
+		a {
+			align-items: center;
+			color: var(--d2l-color-ferrite);
+			display: inline-flex;
+			height: 100%;
+			min-height: 40px;
+			position: relative;
+			text-decoration: none;
+			vertical-align: middle;
+		}
+		a:hover,
+		a:focus {
+			--d2l-icon-fill-color: var(--d2l-color-celestine);
+			color: var(--d2l-color-celestine);
+			outline: none;
+		}
+		:host(:not([href])) .d2l-labs-navigation-highlight-border {
+			display: none;
+		}
+	`];
 
 	static get focusElementSelector() {
 		return 'a';

--- a/src/components/navigation/navigation-main-footer.js
+++ b/src/components/navigation/navigation-main-footer.js
@@ -3,15 +3,13 @@ import { navigationSharedStyle } from './navigation-shared-styles.js';
 
 class NavigationMainFooter extends LitElement {
 
-	static get styles() {
-		return [navigationSharedStyle, css`
-			:host {
-				border-bottom: 1px solid rgba(124, 134, 149, 0.18);
-				border-top: 1px solid rgba(124, 134, 149, 0.18);
-				display: block;
-			}
-		`];
-	}
+	static styles = [navigationSharedStyle, css`
+		:host {
+			border-bottom: 1px solid rgba(124, 134, 149, 0.18);
+			border-top: 1px solid rgba(124, 134, 149, 0.18);
+			display: block;
+		}
+	`];
 
 	render() {
 		return html`

--- a/src/components/navigation/navigation-main-header.js
+++ b/src/components/navigation/navigation-main-header.js
@@ -3,52 +3,50 @@ import { navigationSharedStyle } from './navigation-shared-styles.js';
 
 class NavigationMainHeader extends LitElement {
 
-	static get styles() {
-		return [navigationSharedStyle, css`
-			:host {
-				display: block;
-			}
+	static styles = [navigationSharedStyle, css`
+		:host {
+			display: block;
+		}
 
+		.d2l-labs-navigation-header-container {
+			align-items: center;
+			display: flex;
+			height: 90px;
+		}
+
+		@media (max-width: 767px) {
 			.d2l-labs-navigation-header-container {
-				align-items: center;
-				display: flex;
-				height: 90px;
+				height: 72px;
 			}
+		}
 
-			@media (max-width: 767px) {
-				.d2l-labs-navigation-header-container {
-					height: 72px;
-				}
-			}
+		div ::slotted(.d2l-labs-navigation-header-left),
+		div ::slotted(.d2l-labs-navigation-header-right) {
+			align-items: center;
+			display: flex;
+			height: 100%;
+		}
 
-			div ::slotted(.d2l-labs-navigation-header-left),
-			div ::slotted(.d2l-labs-navigation-header-right) {
-				align-items: center;
-				display: flex;
-				height: 100%;
-			}
+		div ::slotted(.d2l-labs-navigation-header-left) {
+			flex: 0 1 auto;
+		}
 
-			div ::slotted(.d2l-labs-navigation-header-left) {
-				flex: 0 1 auto;
-			}
+		div ::slotted(.d2l-labs-navigation-header-right) {
+			flex: 0 0 auto;
+		}
 
-			div ::slotted(.d2l-labs-navigation-header-right) {
-				flex: 0 0 auto;
-			}
+		.d2l-labs-navigation-gutter {
+			display: inline-block;
+			flex: 1 1 auto;
+			min-width: var(--d2l-labs-navigation-margin-regular);
+		}
 
+		@media (max-width: 615px) {
 			.d2l-labs-navigation-gutter {
-				display: inline-block;
-				flex: 1 1 auto;
-				min-width: var(--d2l-labs-navigation-margin-regular);
+				min-width: var(--d2l-labs-navigation-margin-regular) / 2;
 			}
-
-			@media (max-width: 615px) {
-				.d2l-labs-navigation-gutter {
-					min-width: var(--d2l-labs-navigation-margin-regular) / 2;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	render() {
 		return html`

--- a/src/components/navigation/navigation-notification-icon.js
+++ b/src/components/navigation/navigation-notification-icon.js
@@ -4,41 +4,37 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 class NavigationNotificationIcon extends RtlMixin(LitElement) {
 
-	static get properties() {
-		return {
-			thinBorder: { attribute: 'thin-border', reflect: true, type: Boolean }
-		};
-	}
+	static properties = {
+		thinBorder: { attribute: 'thin-border', reflect: true, type: Boolean }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-				height: 100%;
-				position: absolute;
-				right: calc(-100% + 11px);
-				top: calc(-50% + 11px);
-				width: 100%;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			:host([dir="rtl"]) {
-				left: calc(-50% - 4px);
-				right: auto;
-			}
-			.d2l-labs-navigation-notification-icon-indicator {
-				background: var(--d2l-color-primary-accent-indicator);
-				border: 2px solid white;
-				border-radius: 50%;
-				height: 10px;
-				width: 10px;
-			}
-			:host([thin-border]) .d2l-labs-navigation-notification-icon-indicator {
-				border-width: 1px;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+			height: 100%;
+			position: absolute;
+			right: calc(-100% + 11px);
+			top: calc(-50% + 11px);
+			width: 100%;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+		:host([dir="rtl"]) {
+			left: calc(-50% - 4px);
+			right: auto;
+		}
+		.d2l-labs-navigation-notification-icon-indicator {
+			background: var(--d2l-color-primary-accent-indicator);
+			border: 2px solid white;
+			border-radius: 50%;
+			height: 10px;
+			width: 10px;
+		}
+		:host([thin-border]) .d2l-labs-navigation-notification-icon-indicator {
+			border-width: 1px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/navigation/navigation.js
+++ b/src/components/navigation/navigation.js
@@ -10,29 +10,25 @@ import { getNextFocusable } from '@brightspace-ui/core/helpers/focus.js';
  */
 class Navigation extends LitElement {
 
-	static get properties() {
-		return {
-			hasSkipNav: { attribute: 'has-skip-nav', type: Boolean }
-		};
-	}
+	static properties = {
+		hasSkipNav: { attribute: 'has-skip-nav', type: Boolean }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-				position: relative;
-			}
-			.d2l-labs-navigation-shadow-drop-border {
-				background-color: rgba(0, 0, 0, 0.02);
-				bottom: -4px;
-				display: var(--d2l-labs-navigation-shadow-drop-border-display, block);
-				height: 4px;
-				pointer-events: none;
-				position: absolute;
-				width: 100%;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: block;
+			position: relative;
+		}
+		.d2l-labs-navigation-shadow-drop-border {
+			background-color: rgba(0, 0, 0, 0.02);
+			bottom: -4px;
+			display: var(--d2l-labs-navigation-shadow-drop-border-display, block);
+			height: 4px;
+			pointer-events: none;
+			position: absolute;
+			width: 100%;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/opt-in-flyout/flyout-impl.js
+++ b/src/components/opt-in-flyout/flyout-impl.js
@@ -21,173 +21,165 @@ class FlyoutImplementation extends composeMixins(
 	LocalizeLabsElement
 ) {
 
-	static get properties() {
-		return {
-			optOut: { type: Boolean, attribute: 'opt-out' },
-			opened: { type: Boolean, reflect: true },
-			flyoutTitle: { attribute: 'flyout-title', type: String },
-			shortDescription: { type: String, attribute: 'short-description' },
-			longDescription: { type: String, attribute: 'long-description' },
-			tutorialLink: { type: String, attribute: 'tutorial-link' },
-			helpDocsLink: { type: String, attribute: 'help-docs-link' },
-			hideReason: { type: Boolean, attribute: 'hide-reason' },
-			hideFeedback: { type: Boolean, attribute: 'hide-feedback' },
-			_optOutDialogOpen: { state: true },
-			_primaryButtonText: { state: true },
-			_secondaryButtonText: { state: true },
-			_visibleState: { state: true },
-			_ariaLabel: { state: true },
-			_tabIndex: { state: true }
-		};
-	}
+	static properties = {
+		optOut: { type: Boolean, attribute: 'opt-out' },
+		opened: { type: Boolean, reflect: true },
+		flyoutTitle: { attribute: 'flyout-title', type: String },
+		shortDescription: { type: String, attribute: 'short-description' },
+		longDescription: { type: String, attribute: 'long-description' },
+		tutorialLink: { type: String, attribute: 'tutorial-link' },
+		helpDocsLink: { type: String, attribute: 'help-docs-link' },
+		hideReason: { type: Boolean, attribute: 'hide-reason' },
+		hideFeedback: { type: Boolean, attribute: 'hide-feedback' },
+		_optOutDialogOpen: { state: true },
+		_primaryButtonText: { state: true },
+		_secondaryButtonText: { state: true },
+		_visibleState: { state: true },
+		_ariaLabel: { state: true },
+		_tabIndex: { state: true }
+	};
 
-	static get styles() {
-		return [
-			bodyStandardStyles,
-			heading1Styles,
-			css`
-				:host {
-					height: var(--d2l-flyout-custom-element-height, auto);
-					overflow: hidden;
-					pointer-events: none;
-					position: absolute;
-					width: 100%;
-				}
+	static styles = [bodyStandardStyles, heading1Styles, css`
+		:host {
+			height: var(--d2l-flyout-custom-element-height, auto);
+			overflow: hidden;
+			pointer-events: none;
+			position: absolute;
+			width: 100%;
+		}
 
-				:host([opened]) {
-					background-color: rgba(255, 255, 255, 0.7);
-					height: 100%;
-					pointer-events: auto;
-				}
+		:host([opened]) {
+			background-color: rgba(255, 255, 255, 0.7);
+			height: 100%;
+			pointer-events: auto;
+		}
 
-				#flyout {
-					background-color: white;
-					border-bottom: 1px solid var(--d2l-color-mica);
-					box-sizing: border-box;
-					margin-bottom: 1.2rem;
-					overflow: visible;
-					padding-bottom: 2rem;
-					pointer-events: auto;
-					position: var(--d2l-flyout-custom-element-position, relative);
-					top: var(--d2l-flyout-custom-element-top, 0);
-					width: 100%;
-					z-index: var(--d2l-flyout-custom-element-z-index, 900);
-				}
+		#flyout {
+			background-color: white;
+			border-bottom: 1px solid var(--d2l-color-mica);
+			box-sizing: border-box;
+			margin-bottom: 1.2rem;
+			overflow: visible;
+			padding-bottom: 2rem;
+			pointer-events: auto;
+			position: var(--d2l-flyout-custom-element-position, relative);
+			top: var(--d2l-flyout-custom-element-top, 0);
+			width: 100%;
+			z-index: var(--d2l-flyout-custom-element-z-index, 900);
+		}
 
-				#flyout.flyout-opened {
-					transition: transform 0.2s ease-out;
-				}
+		#flyout.flyout-opened {
+			transition: transform 0.2s ease-out;
+		}
 
-				#flyout.flyout-closed {
-					transition: transform 0.2s ease-in;
-				}
+		#flyout.flyout-closed {
+			transition: transform 0.2s ease-in;
+		}
 
-				.flyout-opened {
-					transform: translateY(0);
-				}
-				.flyout-closed {
-					transform: translateY(-100%);
-				}
+		.flyout-opened {
+			transform: translateY(0);
+		}
+		.flyout-closed {
+			transform: translateY(-100%);
+		}
 
-				.flyout-content {
-					text-align: center;
-				}
+		.flyout-content {
+			text-align: center;
+		}
 
-				.flyout-content h1 {
-					margin-bottom: 1.2rem;
-				}
+		.flyout-content h1 {
+			margin-bottom: 1.2rem;
+		}
 
-				.flyout-text {
-					align-items: center;
-					display: flex;
-					flex-direction: column;
-					margin-bottom: 1.5rem;
-				}
+		.flyout-text {
+			align-items: center;
+			display: flex;
+			flex-direction: column;
+			margin-bottom: 1.5rem;
+		}
 
-				#short-description {
-					margin-bottom: 0.5rem;
-				}
+		#short-description {
+			margin-bottom: 0.5rem;
+		}
 
-				#long-description {
-					max-width: 800px;
-				}
+		#long-description {
+			max-width: 800px;
+		}
 
-				.flyout-tutorial {
-					margin: auto;
-					margin-top: 0.5em;
-				}
+		.flyout-tutorial {
+			margin: auto;
+			margin-top: 0.5em;
+		}
 
-				.flyout-tutorial a {
-					color: var(--d2l-color-celestine);
-					text-decoration: none;
-				}
+		.flyout-tutorial a {
+			color: var(--d2l-color-celestine);
+			text-decoration: none;
+		}
 
-				.flyout-tutorial a:hover, .flyout-tutorial a:focus {
-					text-decoration: underline;
-				}
+		.flyout-tutorial a:hover, .flyout-tutorial a:focus {
+			text-decoration: underline;
+		}
 
-				.flyout-buttons {
-					margin-left: auto;
-					margin-right: auto;
-				}
+		.flyout-buttons {
+			margin-left: auto;
+			margin-right: auto;
+		}
 
-				.flyout-buttons d2l-button {
-					margin-left: 0.5rem;
-					margin-right: 0.5rem;
-				}
+		.flyout-buttons d2l-button {
+			margin-left: 0.5rem;
+			margin-right: 0.5rem;
+		}
 
-				.flyout-tab-container {
-					height: 1.2rem;
-					left: 50%;
-					max-width: 1230px;
-					overflow: hidden;
-					pointer-events: none;
-					position: absolute;
-					top: 100%;
-					transform: translateX(-50%);
-					width: 100%;
-				}
+		.flyout-tab-container {
+			height: 1.2rem;
+			left: 50%;
+			max-width: 1230px;
+			overflow: hidden;
+			pointer-events: none;
+			position: absolute;
+			top: 100%;
+			transform: translateX(-50%);
+			width: 100%;
+		}
 
-				.flyout-tab {
-					background-color: white;
-					border: 1px solid var(--d2l-color-mica);
-					border-radius: 0 0 8px 8px;
-					border-top: none;
-					box-sizing: border-box;
-					cursor: pointer;
-					height: 1rem;
-					inset-block-start: 0;
-					inset-inline-end: 15px;
-					min-height: 0;
-					padding: 1px;
-					pointer-events: auto;
-					position: absolute;
-					text-align: center;
-					width: 5rem;
-				}
+		.flyout-tab {
+			background-color: white;
+			border: 1px solid var(--d2l-color-mica);
+			border-radius: 0 0 8px 8px;
+			border-top: none;
+			box-sizing: border-box;
+			cursor: pointer;
+			height: 1rem;
+			inset-block-start: 0;
+			inset-inline-end: 15px;
+			min-height: 0;
+			padding: 1px;
+			pointer-events: auto;
+			position: absolute;
+			text-align: center;
+			width: 5rem;
+		}
 
-				.flyout-tab:hover, .flyout-tab:focus {
-					background-color: var(--d2l-color-gypsum);
-				}
+		.flyout-tab:hover, .flyout-tab:focus {
+			background-color: var(--d2l-color-gypsum);
+		}
 
-				.flyout-tab:focus {
-					border-color: rgba(0, 111, 191, 0.4);
-					border-style: solid;
-					border-width: 0 1px 1px 1px;
-					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
-				}
+		.flyout-tab:focus {
+			border-color: rgba(0, 111, 191, 0.4);
+			border-style: solid;
+			border-width: 0 1px 1px 1px;
+			box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+		}
 
-				.flyout-tab:active, .flyout-tab:focus {
-					outline: 0;
-				}
+		.flyout-tab:active, .flyout-tab:focus {
+			outline: 0;
+		}
 
-				.flyout-tab > d2l-icon {
-					margin: auto;
-					vertical-align: top !important;
-				}
-			`
-		];
-	}
+		.flyout-tab > d2l-icon {
+			margin: auto;
+			vertical-align: top !important;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/opt-in-flyout/opt-in-flyout.js
+++ b/src/components/opt-in-flyout/opt-in-flyout.js
@@ -4,24 +4,20 @@ import { css, html, LitElement } from 'lit';
 
 class OptInFlyout extends LitElement {
 
-	static get properties() {
-		return {
-			opened: { type: Boolean, reflect: true },
-			flyoutTitle: { attribute: 'flyout-title', type: String },
-			shortDescription: { type: String, attribute: 'short-description' },
-			longDescription: { type: String, attribute: 'long-description' },
-			tutorialLink: { type: String, attribute: 'tutorial-link' },
-			helpDocsLink: { type: String, attribute: 'help-docs-link' }
-		};
-	}
+	static properties = {
+		opened: { type: Boolean, reflect: true },
+		flyoutTitle: { attribute: 'flyout-title', type: String },
+		shortDescription: { type: String, attribute: 'short-description' },
+		longDescription: { type: String, attribute: 'long-description' },
+		tutorialLink: { type: String, attribute: 'tutorial-link' },
+		helpDocsLink: { type: String, attribute: 'help-docs-link' }
+	};
 
-	static get styles() {
-		return css`
-			d2l-labs-opt-in-flyout-impl {
-				font-size: 20px;
-			}
-		`;
-	}
+	static styles = css`
+		d2l-labs-opt-in-flyout-impl {
+			font-size: 20px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/opt-in-flyout/opt-out-dialog.js
+++ b/src/components/opt-in-flyout/opt-out-dialog.js
@@ -13,74 +13,70 @@ const defaultEventProperties = {
 
 class OptOutDialog extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			hideReason: { type: Boolean, attribute: 'hide-reason' },
-			hideFeedback: { type: Boolean, attribute: 'hide-feedback' }
-		};
-	}
+	static properties = {
+		hideReason: { type: Boolean, attribute: 'hide-reason' },
+		hideFeedback: { type: Boolean, attribute: 'hide-feedback' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				height: 100%;
-				overflow: hidden;
-				pointer-events: auto;
-				position: absolute;
-				width: 100%;
-				z-index: 950;
-			}
+	static styles = css`
+		:host {
+			height: 100%;
+			overflow: hidden;
+			pointer-events: auto;
+			position: absolute;
+			width: 100%;
+			z-index: 950;
+		}
 
-			.opt-out-modal-fade {
-				background-color: #ffffff;
-				height: 100%;
-				opacity: 0.7;
-				position: absolute;
-				width: 100%;
-				z-index: 1;
-			}
+		.opt-out-modal-fade {
+			background-color: #ffffff;
+			height: 100%;
+			opacity: 0.7;
+			position: absolute;
+			width: 100%;
+			z-index: 1;
+		}
 
-			.dialog {
-				background-color: #ffffff;
-				border: 1px solid var(--d2l-color-mica);
-				border-radius: 0.3rem;
-				box-shadow: 0 2px 12px rgba(86, 90, 92, 0.25);
-				box-sizing: border-box;
-				left: 50%;
-				max-width: 680px;
-				padding: 1rem;
-				position: absolute;
-				top: 7.5%;
-				transform: translateX(-50%);
-				width: 90%;
-				z-index: 2;
-			}
+		.dialog {
+			background-color: #ffffff;
+			border: 1px solid var(--d2l-color-mica);
+			border-radius: 0.3rem;
+			box-shadow: 0 2px 12px rgba(86, 90, 92, 0.25);
+			box-sizing: border-box;
+			left: 50%;
+			max-width: 680px;
+			padding: 1rem;
+			position: absolute;
+			top: 7.5%;
+			transform: translateX(-50%);
+			width: 90%;
+			z-index: 2;
+		}
 
-			label {
-				display: block;
-				margin-bottom: 0.5rem;
-			}
+		label {
+			display: block;
+			margin-bottom: 0.5rem;
+		}
 
-			#title-label {
-				display: inline;
-				font-weight: bold;
-			}
+		#title-label {
+			display: inline;
+			font-weight: bold;
+		}
 
-			d2l-input-textarea {
-				margin-bottom: 1rem;
-			}
+		d2l-input-textarea {
+			margin-bottom: 1rem;
+		}
 
-			d2l-button {
-				margin-right: 1rem;
-			}
+		d2l-button {
+			margin-right: 1rem;
+		}
 
-			.close-button {
-				inset-block-start: 0.6rem;
-				inset-inline-end: 0.6rem;
-				position: absolute;
-			}
-		`;
-	}
+		.close-button {
+			inset-block-start: 0.6rem;
+			inset-inline-end: 0.6rem;
+			position: absolute;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/opt-in-flyout/opt-out-flyout.js
+++ b/src/components/opt-in-flyout/opt-out-flyout.js
@@ -4,26 +4,22 @@ import { css, html, LitElement } from 'lit';
 
 class OptOutFlyout extends LitElement {
 
-	static get properties() {
-		return {
-			opened: { type: Boolean, reflect: true },
-			flyoutTitle: { attribute: 'flyout-title', type: String },
-			shortDescription: { type: String, attribute: 'short-description' },
-			longDescription: { type: String, attribute: 'long-description' },
-			tutorialLink: { type: String, attribute: 'tutorial-link' },
-			helpDocsLink: { type: String, attribute: 'help-docs-link' },
-			hideReason: { type: Boolean, attribute: 'hide-reason' },
-			hideFeedback: { type: Boolean, attribute: 'hide-feedback' }
-		};
-	}
+	static properties = {
+		opened: { type: Boolean, reflect: true },
+		flyoutTitle: { attribute: 'flyout-title', type: String },
+		shortDescription: { type: String, attribute: 'short-description' },
+		longDescription: { type: String, attribute: 'long-description' },
+		tutorialLink: { type: String, attribute: 'tutorial-link' },
+		helpDocsLink: { type: String, attribute: 'help-docs-link' },
+		hideReason: { type: Boolean, attribute: 'hide-reason' },
+		hideFeedback: { type: Boolean, attribute: 'hide-feedback' }
+	};
 
-	static get styles() {
-		return css`
-			d2l-labs-opt-in-flyout-impl {
-				font-size: 20px;
-			}
-		`;
-	}
+	static styles = css`
+		d2l-labs-opt-in-flyout-impl {
+			font-size: 20px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/opt-in-flyout/opt-out-reason-selector.js
+++ b/src/components/opt-in-flyout/opt-out-reason-selector.js
@@ -5,52 +5,45 @@ import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 class OptOutReasonSelector extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			_reasons: { state: true }
-		};
-	}
+	static properties = {
+		_reasons: { state: true }
+	};
 
-	static get styles() {
-		return [
-			inputStyles,
-			css`
-				label {
-					display: block;
-					margin-bottom: 0.5rem;
-				}
+	static styles = [inputStyles, css`
+		label {
+			display: block;
+			margin-bottom: 0.5rem;
+		}
 
-				select {
-					-moz-appearance: none;
-					-webkit-appearance: none;
-					appearance: none;
-					background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23f2f3f5%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
-					background-position: var(--d2l-inline-end, right) center;
-					background-repeat: no-repeat;
-					background-size: contain;
-					display: block;
-					margin-bottom: 1.5rem !important;
-					position: relative;
-					width: 80%;
-				}
+		select {
+			-moz-appearance: none;
+			-webkit-appearance: none;
+			appearance: none;
+			background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23f2f3f5%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+			background-position: var(--d2l-inline-end, right) center;
+			background-repeat: no-repeat;
+			background-size: contain;
+			display: block;
+			margin-bottom: 1.5rem !important;
+			position: relative;
+			width: 80%;
+		}
 
-				/* for ie11 - avoid displaying default select arrow */
-				select::-ms-expand {
-					display: none;
-				}
+		/* for ie11 - avoid displaying default select arrow */
+		select::-ms-expand {
+			display: none;
+		}
 
-				/* for ie11 - prevent background box from covering select arrow */
-				select::-ms-value {
-					background-color: transparent;
-					color: var(--d2l-input-color);
-				}
+		/* for ie11 - prevent background box from covering select arrow */
+		select::-ms-value {
+			background-color: transparent;
+			color: var(--d2l-input-color);
+		}
 
-				#options {
-					display: none;
-				}
-			`
-		];
-	}
+		#options {
+			display: none;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/opt-in-flyout/opt-out-reason.js
+++ b/src/components/opt-in-flyout/opt-out-reason.js
@@ -2,20 +2,16 @@ import { css, LitElement } from 'lit';
 
 class OptOutReason extends LitElement {
 
-	static get properties() {
-		return {
-			key: { type: String },
-			text: { type: String }
-		};
-	}
+	static properties = {
+		key: { type: String },
+		text: { type: String }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: none;
+		}
+	`;
 
 }
 

--- a/src/components/ou-filter/ou-filter.js
+++ b/src/components/ou-filter/ou-filter.js
@@ -54,24 +54,20 @@ export class OuFilterDataManager {
  */
 class OuFilter extends LocalizeLabsElement(MobxLitElement) {
 
-	static get properties() {
-		return {
-			dataManager: { type: Object, attribute: false },
-			isSelectAllVisible: { type: Boolean, attribute: 'select-all-ui', reflect: true },
-			disabled: { type: Boolean, attribute: 'disabled' }
-		};
-	}
+	static properties = {
+		dataManager: { type: Object, attribute: false },
+		isSelectAllVisible: { type: Boolean, attribute: 'select-all-ui', reflect: true },
+		disabled: { type: Boolean, attribute: 'disabled' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-		`;
-	}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/ou-filter/tree-filter.js
+++ b/src/components/ou-filter/tree-filter.js
@@ -554,33 +554,29 @@ decorate(Tree, {
  */
 class TreeFilter extends LocalizeLabsElement(MobxLitElement) {
 
-	static get properties() {
-		return {
-			tree: { type: Object, attribute: false },
-			openerText: { type: String, attribute: 'opener-text' },
-			openerTextSelected: { type: String, attribute: 'opener-text-selected' },
-			searchString: { type: String, attribute: 'search-string', reflect: true },
-			isLoadMoreSearch: { type: Boolean, attribute: 'load-more-search', reflect: true },
-			isSelectAllVisible: { type: Boolean, attribute: 'select-all-ui', reflect: true },
-			disabled: { type: Boolean, attribute: 'disabled' },
-			_isLoadingSearch: { type: Boolean, attribute: false }
-		};
-	}
+	static properties = {
+		tree: { type: Object, attribute: false },
+		openerText: { type: String, attribute: 'opener-text' },
+		openerTextSelected: { type: String, attribute: 'opener-text-selected' },
+		searchString: { type: String, attribute: 'search-string', reflect: true },
+		isLoadMoreSearch: { type: Boolean, attribute: 'load-more-search', reflect: true },
+		isSelectAllVisible: { type: Boolean, attribute: 'select-all-ui', reflect: true },
+		disabled: { type: Boolean, attribute: 'disabled' },
+		_isLoadingSearch: { type: Boolean, attribute: false }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: inline-block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
 
-			d2l-button.d2l-tree-load-more {
-				padding-bottom: 12px;
-			}
-		`;
-	}
+		d2l-button.d2l-tree-load-more {
+			padding-bottom: 12px;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/ou-filter/tree-selector-node.js
+++ b/src/components/ou-filter/tree-selector-node.js
@@ -15,77 +15,73 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
  *
  */
 class TreeSelectorNode extends LocalizeLabsElement(RtlMixin(LitElement)) {
-	static get properties() {
-		return {
-			name: { type: String },
-			dataId: { type: Number, attribute: 'data-id' },
-			isOpen: { type: Boolean, reflect: true, attribute: 'open' },
-			selectedState: { type: String, reflect: true, attribute: 'selected-state' },
-			isOpenable: { type: Boolean, reflect: true, attribute: 'openable' },
-			// for screen readers
-			indentLevel: { type: Number, attribute: 'indent-level' },
-			parentName: { type: String, attribute: 'parent-name' },
-			// for search: if isSearch, only search-result nodes are shown; the caller should ensure their ancestors are open
-			isSearch: { type: Boolean, reflect: true, attribute: 'search' },
-			isSearchResult: { type: Boolean, reflect: true, attribute: 'search-result' }
-		};
-	}
+	static properties = {
+		name: { type: String },
+		dataId: { type: Number, attribute: 'data-id' },
+		isOpen: { type: Boolean, reflect: true, attribute: 'open' },
+		selectedState: { type: String, reflect: true, attribute: 'selected-state' },
+		isOpenable: { type: Boolean, reflect: true, attribute: 'openable' },
+		// for screen readers
+		indentLevel: { type: Number, attribute: 'indent-level' },
+		parentName: { type: String, attribute: 'parent-name' },
+		// for search: if isSearch, only search-result nodes are shown; the caller should ensure their ancestors are open
+		isSearch: { type: Boolean, reflect: true, attribute: 'search' },
+		isSearchResult: { type: Boolean, reflect: true, attribute: 'search-result' }
+	};
 
-	static get styles() {
-		return css`
-			:host {
-				display: block;
-				font-size: 0.8rem;
-			}
-			:host([hidden]) {
-				display: none;
-			}
+	static styles = css`
+		:host {
+			display: block;
+			font-size: 0.8rem;
+		}
+		:host([hidden]) {
+			display: none;
+		}
 
-			.d2l-labs-tree-selector-node-node {
-				display: flex;
-				flex-wrap: nowrap;
-				margin-bottom: 16px;
-			}
+		.d2l-labs-tree-selector-node-node {
+			display: flex;
+			flex-wrap: nowrap;
+			margin-bottom: 16px;
+		}
 
-			d2l-input-checkbox {
-				display: inline-block;
-			}
+		d2l-input-checkbox {
+			display: inline-block;
+		}
 
-			.d2l-labs-tree-selector-node-open-control {
-				cursor: default;
-				margin-top: -3px;
-			}
-			.d2l-labs-tree-selector-node-open-control .d2l-labs-tree-selector-node-open {
-				display: none;
-			}
-			.d2l-labs-tree-selector-node-open-control[open] .d2l-labs-tree-selector-node-open {
-				display: inline-block;
-			}
-			.d2l-labs-tree-selector-node-open-control[open] .d2l-labs-tree-selector-node-closed {
-				display: none;
-			}
+		.d2l-labs-tree-selector-node-open-control {
+			cursor: default;
+			margin-top: -3px;
+		}
+		.d2l-labs-tree-selector-node-open-control .d2l-labs-tree-selector-node-open {
+			display: none;
+		}
+		.d2l-labs-tree-selector-node-open-control[open] .d2l-labs-tree-selector-node-open {
+			display: inline-block;
+		}
+		.d2l-labs-tree-selector-node-open-control[open] .d2l-labs-tree-selector-node-closed {
+			display: none;
+		}
 
-			.d2l-labs-tree-selector-node-subtree {
-				margin-left: 34px;
-				margin-right: 0;
-			}
-			:host([dir="rtl"]) .d2l-labs-tree-selector-node-subtree {
-				margin-left: 0;
-				margin-right: 34px;
-			}
-			.d2l-labs-tree-selector-node-subtree[hidden] {
-				display: none;
-			}
+		.d2l-labs-tree-selector-node-subtree {
+			margin-left: 34px;
+			margin-right: 0;
+		}
+		:host([dir="rtl"]) .d2l-labs-tree-selector-node-subtree {
+			margin-left: 0;
+			margin-right: 34px;
+		}
+		.d2l-labs-tree-selector-node-subtree[hidden] {
+			display: none;
+		}
 
-			.d2l-labs-tree-selector-node-text {
-				cursor: default;
-				display: inline-block;
-				margin-left: 0.5rem;
-				margin-right: 0.5rem;
-				width: 100%;
-			}
-		`;
-	}
+		.d2l-labs-tree-selector-node-text {
+			cursor: default;
+			display: inline-block;
+			margin-left: 0.5rem;
+			margin-right: 0.5rem;
+			width: 100%;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/components/ou-filter/tree-selector.js
+++ b/src/components/ou-filter/tree-selector.js
@@ -24,69 +24,62 @@ const DROPDOWN_WIDTH = 368;
  */
 class TreeSelector extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			name: { type: String },
-			disabled: { type: Boolean, attribute: 'disabled' },
-			isSelectAllVisible: { type: Boolean, attribute: 'select-all-ui', reflect: true },
-			isSearch: { type: Boolean, attribute: 'search', reflect: true },
-			isSelected: { type: Boolean, attribute: 'selected', reflect: true },
-			_dropdownMinWidth: { type: Number },
-			_dropdownMaxWidth: { type: Number },
-		};
-	}
+	static properties = {
+		name: { type: String },
+		disabled: { type: Boolean, attribute: 'disabled' },
+		isSelectAllVisible: { type: Boolean, attribute: 'select-all-ui', reflect: true },
+		isSearch: { type: Boolean, attribute: 'search', reflect: true },
+		isSelected: { type: Boolean, attribute: 'selected', reflect: true },
+		_dropdownMinWidth: { type: Number },
+		_dropdownMaxWidth: { type: Number },
+	};
 
-	static get styles() {
-		return [
-			selectStyles,
-			css`
-				:host {
-					display: inline-block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
+	static styles = [selectStyles, css`
+		:host {
+			display: inline-block;
+		}
+		:host([hidden]) {
+			display: none;
+		}
 
-				.d2l-labs-filter-dropdown-content-header {
-					display: flex;
-					justify-content: start;
-				}
-				.d2l-labs-filter-dropdown-content-header > span {
-					align-self: center;
-				}
+		.d2l-labs-filter-dropdown-content-header {
+			display: flex;
+			justify-content: start;
+		}
+		.d2l-labs-filter-dropdown-content-header > span {
+			align-self: center;
+		}
 
-				.d2l-labs-tree-selector-margin-button {
-					margin-inline-end: 6px;
-				}
+		.d2l-labs-tree-selector-margin-button {
+			margin-inline-end: 6px;
+		}
 
-				.d2l-labs-tree-selector-margin-auto {
-					margin-inline-start: auto;
-				}
+		.d2l-labs-tree-selector-margin-auto {
+			margin-inline-start: auto;
+		}
 
-				.d2l-labs-tree-selector-search {
-					display: flex;
-					flex-wrap: nowrap;
-					padding-bottom: 26px;
-					padding-top: 4px;
-				}
-				@media screen and (max-width: 400px) {
-					.d2l-labs-tree-selector-search {
-						width: 100%;
-					}
-				}
-				:host([search]) d2l-dropdown d2l-dropdown-content .d2l-labs-tree-selector-tree {
-					display: none;
-				}
+		.d2l-labs-tree-selector-search {
+			display: flex;
+			flex-wrap: nowrap;
+			padding-bottom: 26px;
+			padding-top: 4px;
+		}
+		@media screen and (max-width: 400px) {
+			.d2l-labs-tree-selector-search {
+				width: 100%;
+			}
+		}
+		:host([search]) d2l-dropdown d2l-dropdown-content .d2l-labs-tree-selector-tree {
+			display: none;
+		}
 
-				.d2l-labs-tree-selector-search-results {
-					display: none;
-				}
-				:host([search]) d2l-dropdown d2l-dropdown-content .d2l-labs-tree-selector-search-results {
-					display: block;
-				}
-			`
-		];
-	}
+		.d2l-labs-tree-selector-search-results {
+			display: none;
+		}
+		:host([search]) d2l-dropdown d2l-dropdown-content .d2l-labs-tree-selector-search-results {
+			display: block;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/pagination/pager-numeric.js
+++ b/src/components/pagination/pager-numeric.js
@@ -8,51 +8,47 @@ import { selectStyles } from '@brightspace-ui/core/components/inputs/input-selec
 
 class PagerNumeric extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			maxPageNumber: { type: Number, attribute: 'max-page-number', reflect: true },
-			pageNumber: { type: Number, attribute: 'page-number', reflect: true },
-			pageSize : { type: Number, attribute: 'page-size', reflect: true },
-			pageSizes : { type: Array, attribute: 'page-sizes' },
-			showPageSizeSelector : { type: Boolean, attribute: 'show-page-size-selector', reflect: true }
-		};
-	}
+	static properties = {
+		maxPageNumber: { type: Number, attribute: 'max-page-number', reflect: true },
+		pageNumber: { type: Number, attribute: 'page-number', reflect: true },
+		pageSize : { type: Number, attribute: 'page-size', reflect: true },
+		pageSizes : { type: Array, attribute: 'page-sizes' },
+		showPageSizeSelector : { type: Boolean, attribute: 'show-page-size-selector', reflect: true }
+	};
 
-	static get styles() {
-		return [selectStyles, css`
+	static styles = [selectStyles, css`
+		:host {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+			white-space: nowrap;
+		}
+
+		.d2l-page-selector-container {
+			margin: 0.75rem;
+		}
+
+		.d2l-page-number-container {
+			direction: ltr;
+			display: inline-block;
+		}
+
+		d2l-input-number {
+			margin-left: 0.25rem;
+			margin-right: 0.25rem;
+			width: 3.8rem;
+		}
+
+		.d2l-page-max-text {
+			margin-right: 0.25rem;
+		}
+
+		@media (max-width: 544px) {
 			:host {
-				align-items: center;
-				display: flex;
-				justify-content: center;
-				white-space: nowrap;
+				flex-direction: column-reverse;
 			}
-
-			.d2l-page-selector-container {
-				margin: 0.75rem;
-			}
-
-			.d2l-page-number-container {
-				direction: ltr;
-				display: inline-block;
-			}
-
-			d2l-input-number {
-				margin-left: 0.25rem;
-				margin-right: 0.25rem;
-				width: 3.8rem;
-			}
-
-			.d2l-page-max-text {
-				margin-right: 0.25rem;
-			}
-
-			@media (max-width: 544px) {
-				:host {
-					flex-direction: column-reverse;
-				}
-			}
-		`];
-	}
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/view-toggle/view-toggle.js
+++ b/src/components/view-toggle/view-toggle.js
@@ -3,90 +3,88 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import { css, html, LitElement } from 'lit';
 
 class ViewToggle extends LitElement {
-	static get properties() {
-		return {
-			text: {
-				type: String
-			},
-			toggleOptions: {
-				type: Array,
-				attribute: 'toggle-options'
-			},
-			selectedOption: {
-				type: String,
-				attribute: 'selected-option'
-			}
-		};
-	}
-	static get styles() {
-		return [
-			css`
-			button.d2l-labs-view-toggle-left {
-				border-end-start-radius: 0.3rem;
-				border-inline-end-color: transparent;
-				border-inline-start-color: var(--d2l-color-mica);
-				border-start-start-radius: 0.3rem;
-			}
-			button.d2l-labs-view-toggle-right {
-				border-end-end-radius: 0.3rem;
-				border-inline-end-color: var(--d2l-color-mica);
-				border-inline-start-color: transparent;
-				border-start-end-radius: 0.3rem;
-			}
-			button {
-				background-color: var(--d2l-color-sylvite);
-				border-color: var(--d2l-color-mica);
-				border-style: solid;
-				border-width: 1px;
-				box-sizing: border-box;
-				color: var(--d2l-color-ferrite);
-				cursor: pointer;
-				display: inline;
-				flex: 0 1;
-				font-family: inherit;
-				font-size: 0.7rem;
-				font-weight: 700;
-				margin: 0;
-				min-height: calc(2rem + 2px);
-				outline: none;
-				padding: 0.5rem 1.5rem;
-				text-align: center;
-				transition: box-shadow 0.2s;
-				-webkit-user-select: none;
-				-moz-user-select: none;
-				-ms-user-select: none;
-				user-select: none;
-				vertical-align: middle;
-				white-space: nowrap;
-			}
-			button:hover, button:focus {
-				border: 1px solid var(--d2l-color-celestine) !important;
-			}
-			button[aria-pressed="true"] {
-				background-color: var(--d2l-color-tungsten);
-				border-color: var(--d2l-color-tungsten);
-				color: var(--d2l-color-regolith);
-			}
-			button[aria-pressed="true"]:hover, button[aria-pressed="true"]:focus {
-				box-shadow: inset 0 0 0 2px #ffffff;
-			}
 
-			span {
-				margin-inline-end: 6px;
-			}
+	static properties = {
+		text: {
+			type: String
+		},
+		toggleOptions: {
+			type: Array,
+			attribute: 'toggle-options'
+		},
+		selectedOption: {
+			type: String,
+			attribute: 'selected-option'
+		}
+	};
 
-			:host {
-				display: block;
-				width: auto;
-			}
+	static styles = [
+		css`
+		button.d2l-labs-view-toggle-left {
+			border-end-start-radius: 0.3rem;
+			border-inline-end-color: transparent;
+			border-inline-start-color: var(--d2l-color-mica);
+			border-start-start-radius: 0.3rem;
+		}
+		button.d2l-labs-view-toggle-right {
+			border-end-end-radius: 0.3rem;
+			border-inline-end-color: var(--d2l-color-mica);
+			border-inline-start-color: transparent;
+			border-start-end-radius: 0.3rem;
+		}
+		button {
+			background-color: var(--d2l-color-sylvite);
+			border-color: var(--d2l-color-mica);
+			border-style: solid;
+			border-width: 1px;
+			box-sizing: border-box;
+			color: var(--d2l-color-ferrite);
+			cursor: pointer;
+			display: inline;
+			flex: 0 1;
+			font-family: inherit;
+			font-size: 0.7rem;
+			font-weight: 700;
+			margin: 0;
+			min-height: calc(2rem + 2px);
+			outline: none;
+			padding: 0.5rem 1.5rem;
+			text-align: center;
+			transition: box-shadow 0.2s;
+			-webkit-user-select: none;
+			-moz-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+			vertical-align: middle;
+			white-space: nowrap;
+		}
+		button:hover, button:focus {
+			border: 1px solid var(--d2l-color-celestine) !important;
+		}
+		button[aria-pressed="true"] {
+			background-color: var(--d2l-color-tungsten);
+			border-color: var(--d2l-color-tungsten);
+			color: var(--d2l-color-regolith);
+		}
+		button[aria-pressed="true"]:hover, button[aria-pressed="true"]:focus {
+			box-shadow: inset 0 0 0 2px #ffffff;
+		}
 
-			.view-toggle-container {
-				align-items: center;
-				display: flex;
-				flex-wrap: nowrap;
-			}`
-		];
-	}
+		span {
+			margin-inline-end: 6px;
+		}
+
+		:host {
+			display: block;
+			width: auto;
+		}
+
+		.view-toggle-container {
+			align-items: center;
+			display: flex;
+			flex-wrap: nowrap;
+		}`
+	];
 
 	render() {
 		return html`

--- a/src/components/wizard/single-step-header.js
+++ b/src/components/wizard/single-step-header.js
@@ -4,117 +4,113 @@ import { LocalizeLabsElement } from '../localize-labs-element.js';
 
 class D2LSingleStepHeader extends LocalizeLabsElement(LitElement) {
 
-	static get properties() {
-		return {
-			stepTitle: {
-				type: String,
-				attribute: 'step-title'
-			},
-			totalSteps: {
-				type: Number,
-				attribute: 'total-steps'
-			},
-			currentStep: {
-				type: Number,
-				attribute: 'current-step'
-			},
-			selectedStep: {
-				type: Number,
-				attribute: 'selected-step'
-			},
-			fillHeaderWidth: {
-				type: Boolean,
-				attribute: 'fill-header-width',
-				reflect: true
-			}
-		};
-	}
+	static properties = {
+		stepTitle: {
+			type: String,
+			attribute: 'step-title'
+		},
+		totalSteps: {
+			type: Number,
+			attribute: 'total-steps'
+		},
+		currentStep: {
+			type: Number,
+			attribute: 'current-step'
+		},
+		selectedStep: {
+			type: Number,
+			attribute: 'selected-step'
+		},
+		fillHeaderWidth: {
+			type: Boolean,
+			attribute: 'fill-header-width',
+			reflect: true
+		}
+	};
 
-	static get styles() {
-		return [bodySmallStyles, css`
-			.d2l-labs-single-step-header-circle {
-				border: 2px solid;
-				border-radius: 50%;
-				height: 26px;
-				width: 26px;
-			}
+	static styles = [bodySmallStyles, css`
+		.d2l-labs-single-step-header-circle {
+			border: 2px solid;
+			border-radius: 50%;
+			height: 26px;
+			width: 26px;
+		}
 
-			.d2l-labs-single-step-header-inner-progress-circle {
-				background-color: var(--d2l-color-celestine);
-				border-radius: 50%;
-				height: 22px;
-				margin: 2px;
-				width: 22px;
-			}
+		.d2l-labs-single-step-header-inner-progress-circle {
+			background-color: var(--d2l-color-celestine);
+			border-radius: 50%;
+			height: 22px;
+			margin: 2px;
+			width: 22px;
+		}
 
-			.d2l-labs-single-step-header-step {
-				display: inline-block;
-				text-align: center;
-			}
+		.d2l-labs-single-step-header-step {
+			display: inline-block;
+			text-align: center;
+		}
 
-			hr {
-				height: 4px;
-				margin: auto;
-				width: 60px;
-			}
+		hr {
+			height: 4px;
+			margin: auto;
+			width: 60px;
+		}
 
-			.d2l-labs-single-step-header-step-header {
-				display: flex;
-			}
+		.d2l-labs-single-step-header-step-header {
+			display: flex;
+		}
 
-			.d2l-labs-single-step-header-step-title {
-				background: none !important;
-				border: none !important;
-				color: var(--d2l-color-ferrite);
-				margin: auto;
-				max-width: 120px;
-				overflow-wrap: break-word;
-			}
+		.d2l-labs-single-step-header-step-title {
+			background: none !important;
+			border: none !important;
+			color: var(--d2l-color-ferrite);
+			margin: auto;
+			max-width: 120px;
+			overflow-wrap: break-word;
+		}
 
-			:host([fill-header-width]) .d2l-labs-single-step-header-step-title {
-				max-width: 150px;
-			}
+		:host([fill-header-width]) .d2l-labs-single-step-header-step-title {
+			max-width: 150px;
+		}
 
-			.d2l-labs-single-step-header-done-icon {
-				color: var(--d2l-color-olivine);
-				height: 20px;
-				padding: 2px;
-				width: 20px;
-			}
+		.d2l-labs-single-step-header-done-icon {
+			color: var(--d2l-color-olivine);
+			height: 20px;
+			padding: 2px;
+			width: 20px;
+		}
 
-			.d2l-labs-single-step-header-done {
-				border-color: var(--d2l-color-olivine);
-				color: var(--d2l-color-olivine);
-			}
+		.d2l-labs-single-step-header-done {
+			border-color: var(--d2l-color-olivine);
+			color: var(--d2l-color-olivine);
+		}
 
-			.d2l-labs-single-step-header-done hr,
-			.d2l-labs-single-step-header-in-progress hr:first-child {
-				background: var(--d2l-color-olivine);
-				border: var(--d2l-color-olivine);
-			}
+		.d2l-labs-single-step-header-done hr,
+		.d2l-labs-single-step-header-in-progress hr:first-child {
+			background: var(--d2l-color-olivine);
+			border: var(--d2l-color-olivine);
+		}
 
-			.d2l-labs-single-step-header-in-progress {
-				border-color: var(--d2l-color-celestine);
-				color: var(--d2l-color-celestine);
-			}
+		.d2l-labs-single-step-header-in-progress {
+			border-color: var(--d2l-color-celestine);
+			color: var(--d2l-color-celestine);
+		}
 
-			.d2l-labs-single-step-header-not-started .d2l-labs-single-step-header-circle {
-				background-color: var(--d2l-color-mica);
-				border-color: var(--d2l-color-mica);
-			}
+		.d2l-labs-single-step-header-not-started .d2l-labs-single-step-header-circle {
+			background-color: var(--d2l-color-mica);
+			border-color: var(--d2l-color-mica);
+		}
 
-			.d2l-labs-single-step-header-in-progress hr:last-child,
-			.d2l-labs-single-step-header-not-started hr {
-				background: var(--d2l-color-mica);
-				border: var(--d2l-color-mica);
-			}
+		.d2l-labs-single-step-header-in-progress hr:last-child,
+		.d2l-labs-single-step-header-not-started hr {
+			background: var(--d2l-color-mica);
+			border: var(--d2l-color-mica);
+		}
 
-			.d2l-labs-single-step-header-first hr:first-child,
-			.d2l-labs-single-step-header-last hr:last-child {
-				visibility: hidden;
-			}
-		`];
-	}
+		.d2l-labs-single-step-header-first hr:first-child,
+		.d2l-labs-single-step-header-last hr:last-child {
+			visibility: hidden;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/wizard/wizard-step.js
+++ b/src/components/wizard/wizard-step.js
@@ -4,76 +4,73 @@ import { LocalizeLabsElement } from '../localize-labs-element.js';
 import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offscreen.js';
 
 class D2LStep extends LocalizeLabsElement(LitElement) {
-	static get properties() {
-		return {
-			nextButtonTitle: {
-				type: String,
-				attribute: 'next-button-title'
-			},
-			nextButtonTooltip: {
-				type: String,
-				attribute: 'next-button-tooltip'
-			},
-			restartButtonTitle: {
-				type: String,
-				attribute: 'restart-button-title'
-			},
-			restartButtonTooltip: {
-				type: String,
-				attribute: 'restart-button-tooltip'
-			},
-			hideRestartButton: {
-				type: Boolean,
-				attribute: 'hide-restart-button'
-			},
-			hideNextButton: {
-				type: Boolean,
-				attribute: 'hide-next-button'
-			},
-			disableNextButton: {
-				type: Boolean,
-				attribute: 'disable-next-button'
-			},
-			nextButtonAriaLabel: {
-				type: String,
-				attribute: 'next-button-aria-label'
-			},
-			restartButtonAriaLabel: {
-				type: String,
-				attribute: 'restart-button-aria-label'
-			},
-			ariaTitle: {
-				type: String,
-				attribute: 'aria-title'
-			},
-			stepTitle: {
-				type: String,
-				attribute: 'step-title'
-			},
-			stepCount: {
-				type: Number,
-				attribute: 'step-count'
-			},
-			thisStep: {
-				type: Number,
-				attribute: 'this-step'
-			}
-		};
-	}
 
-	static get styles() {
-		return [offscreenStyles, css`
-			.d2l-labs-wizard-step-footer {
-				display: flex;
-				justify-content: space-between;
-				width: 100%;
-			}
+	static properties = {
+		nextButtonTitle: {
+			type: String,
+			attribute: 'next-button-title'
+		},
+		nextButtonTooltip: {
+			type: String,
+			attribute: 'next-button-tooltip'
+		},
+		restartButtonTitle: {
+			type: String,
+			attribute: 'restart-button-title'
+		},
+		restartButtonTooltip: {
+			type: String,
+			attribute: 'restart-button-tooltip'
+		},
+		hideRestartButton: {
+			type: Boolean,
+			attribute: 'hide-restart-button'
+		},
+		hideNextButton: {
+			type: Boolean,
+			attribute: 'hide-next-button'
+		},
+		disableNextButton: {
+			type: Boolean,
+			attribute: 'disable-next-button'
+		},
+		nextButtonAriaLabel: {
+			type: String,
+			attribute: 'next-button-aria-label'
+		},
+		restartButtonAriaLabel: {
+			type: String,
+			attribute: 'restart-button-aria-label'
+		},
+		ariaTitle: {
+			type: String,
+			attribute: 'aria-title'
+		},
+		stepTitle: {
+			type: String,
+			attribute: 'step-title'
+		},
+		stepCount: {
+			type: Number,
+			attribute: 'step-count'
+		},
+		thisStep: {
+			type: Number,
+			attribute: 'this-step'
+		}
+	};
 
-			.d2l-labs-wizard-step-button-next {
-				float: right;
-			}
-		`];
-	}
+	static styles = [offscreenStyles, css`
+		.d2l-labs-wizard-step-footer {
+			display: flex;
+			justify-content: space-between;
+			width: 100%;
+		}
+
+		.d2l-labs-wizard-step-button-next {
+			float: right;
+		}
+	`];
 
 	constructor() {
 		super();

--- a/src/components/wizard/wizard.js
+++ b/src/components/wizard/wizard.js
@@ -2,40 +2,37 @@ import './single-step-header.js';
 import { css, html, LitElement } from 'lit';
 
 class D2LWizard extends LitElement {
-	static get properties() {
-		return {
-			stepTitles: {
-				type: Array,
-				attribute: 'step-titles'
-			},
-			stepCount: {
-				type: Number,
-				attribute: 'step-count'
-			},
-			selectedStep: {
-				type: Number,
-				attribute: 'selected-step'
-			},
-			fillHeaderWidth: {
-				type: Boolean,
-				attribute: 'fill-header-width',
-				reflect: true
-			}
-		};
-	}
 
-	static get styles() {
-		return css`
-			.d2l-labs-wizard-header {
-				display: flex;
-				flex: 1;
-				justify-content: center;
-				margin: 30px 0;
-				overflow-x: auto;
-				width: 100%;
-			}
-		`;
-	}
+	static properties = {
+		stepTitles: {
+			type: Array,
+			attribute: 'step-titles'
+		},
+		stepCount: {
+			type: Number,
+			attribute: 'step-count'
+		},
+		selectedStep: {
+			type: Number,
+			attribute: 'selected-step'
+		},
+		fillHeaderWidth: {
+			type: Boolean,
+			attribute: 'fill-header-width',
+			reflect: true
+		}
+	};
+
+	static styles = css`
+		.d2l-labs-wizard-header {
+			display: flex;
+			flex: 1;
+			justify-content: center;
+			margin: 30px 0;
+			overflow-x: auto;
+			width: 100%;
+		}
+	`;
 
 	constructor() {
 		super();

--- a/src/utilities/reactive-store/README.md
+++ b/src/utilities/reactive-store/README.md
@@ -17,11 +17,10 @@ import ReactiveStore from '@brightspace-ui/labs/utilities/reactive-store.js';
 
 // Define your store with its reactive properties
 class MyStore extends ReactiveStore {
-	static get properties() {
-		return {
-			count: { type: Number },
-		};
-	}
+
+	static properties = {
+		count: { type: Number },
+	};
 
 	constructor() {
 		super();
@@ -104,11 +103,9 @@ import ReactiveStore from '@brightspace-ui/labs/utilities/reactive-store.js';
 
 // Define your store with its reactive properties
 class MyStore extends ReactiveStore {
-	static get properties() {
-		return {
-			count: { type: Number },
-		};
-	}
+	static properties = {
+		count: { type: Number },
+	};
 
 	constructor() {
 		super();
@@ -243,11 +240,9 @@ import ReactiveStore from '@brightspace-ui/labs/utilities/reactive-store.js';
 
 // Define your store with its reactive properties
 class MyStore extends ReactiveStore {
-	static get properties() {
-		return {
-			count: { type: Number },
-		};
-	}
+	static properties = {
+		count: { type: Number },
+	};
 
 	constructor() {
 		super();

--- a/test/utilities/router/helpers/lazy-comp.js
+++ b/test/utilities/router/helpers/lazy-comp.js
@@ -1,9 +1,7 @@
 import { html, LitElement } from 'lit';
 
 class LazyView extends LitElement {
-	static get properties() {
-		return {};
-	}
+	static properties = {};
 
 	render() {
 		return html`<p>Hello</p>`;

--- a/test/utilities/router/helpers/main-view.js
+++ b/test/utilities/router/helpers/main-view.js
@@ -2,11 +2,9 @@ import { LitElement } from 'lit';
 import { RouteReactor } from '../../../../src/utilities/router/index.js';
 
 class MainView extends LitElement {
-	static get properties() {
-		return {
-			'main-prop': { type: String, attribute: true },
-		};
-	}
+	static properties = {
+		'main-prop': { type: String, attribute: true },
+	};
 
 	constructor() {
 		super();

--- a/test/utilities/router/helpers/param-query-view.js
+++ b/test/utilities/router/helpers/param-query-view.js
@@ -2,12 +2,10 @@ import { html, LitElement } from 'lit';
 import { RouteReactor } from '../../../../src/utilities/router/index.js';
 
 class ParamQueryView extends LitElement {
-	static get properties() {
-		return {
-			params: { type: Object, attribute: false },
-			search: { type: Object, attribute: false },
-		};
-	}
+	static properties = {
+		params: { type: Object, attribute: false },
+		search: { type: Object, attribute: false },
+	};
 
 	constructor() {
 		super();


### PR DESCRIPTION
> Disclaimer: this is mostly AI-generated. I've reviewed it myself and do not expect anyone to fully review it line by line.

This is converts from static getters:
```javascript
static get properties() {
  return {
    ...
  };
}
```

To static class level properties:
```javascript
static properties = {
  ...
};
```

And the same for `styles`!

Much easier reviewed with whitespace OFF.