### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "/demo/components/ou-filter/*.js"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@adobe/lit-mobx": "^2",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564